### PR TITLE
Generate reproducible loopy kernels

### DIFF
--- a/pytato/codegen.py
+++ b/pytato/codegen.py
@@ -928,7 +928,9 @@ def generate_loopy(result: Union[Array, DictOfNamedArrays],
 
     # Generate code for graph nodes.
     cg_mapper = CodeGenMapper()
-    for name, val in namespace.items():
+    for name, val in sorted(namespace.items(),
+                            key=lambda x: x[0]  # lexicographic order of names
+                            ):
         _ = cg_mapper(val, state)
 
     # Generate code for outputs.


### PR DESCRIPTION
Traversal order of `DataWrapper`'s determines order of `LoopKernel.args", having them reproducible is necessary for on-disk cache hits.