### PR TITLE
Default to enabling return_dict when dictionary is passed to generate_loopy

### DIFF
--- a/examples/demo.py
+++ b/examples/demo.py
@@ -17,9 +17,9 @@ ctx = cl.create_some_context()
 queue = cl.CommandQueue(ctx)
 prg = pt.generate_loopy(result, cl_device=queue.device)
 a = np.random.randn(20, 20)
-_, (a2a, aat) = prg(queue, a=a)
-assert np.allclose(a2a, a@(2*a))
-assert np.allclose(aat, a@a.T)
+_, out = prg(queue, a=a)
+assert np.allclose(out["a2a"], a@(2*a))
+assert np.allclose(out["aat"], a@a.T)
 
 # }}}
 

--- a/pytato/target/loopy/codegen.py
+++ b/pytato/target/loopy/codegen.py
@@ -665,7 +665,13 @@ def generate_loopy(result: Union[Array, DictOfNamedArrays, Dict[str, Array]],
     :param options: Code generation options for the kernel.
     :returns: A :class:`pytato.program.BoundProgram` wrapping the generated
         :mod:`loopy` program.
+
+    If *result* is a :class:`dict` or a :class:`DictOfNamedArrays` and *options*
+    is not supplied, then the Loopy option :attr:`~loopy.Options.return_dict`
+    will be set to *True*.
     """
+
+    result_is_dict = isinstance(result, (dict, DictOfNamedArrays))
     orig_outputs: DictOfNamedArrays = normalize_outputs(result)
     del result
 
@@ -676,6 +682,9 @@ def generate_loopy(result: Union[Array, DictOfNamedArrays, Dict[str, Array]],
     outputs = preproc_result.outputs
     compute_order = preproc_result.compute_order
     namespace = outputs.namespace
+
+    if options is None and result_is_dict:
+        options = lp.Options(return_dict=True)
 
     state = get_initial_codegen_state(namespace, target, options)
 


### PR DESCRIPTION
Draft because:

- [x] Requires/lives on top of #48 

cc @matthiasdiener