### PR TITLE
call_loopy: perform shape inference and infer loopy size parameters

### DIFF
--- a/pytato/codegen.py
+++ b/pytato/codegen.py
@@ -150,8 +150,8 @@ class CodeGenPreprocessor(CopyMapper):
                     for name, subexpr in expr.bindings.items()}
 
         return LoopyCall(translation_unit=translation_unit,
-                             bindings=bindings,  # type: ignore
-                             entrypoint=entrypoint)
+                         bindings=bindings,
+                         entrypoint=entrypoint)
 
     def map_data_wrapper(self, expr: DataWrapper) -> Array:
         name = expr.name

--- a/pytato/loopy.py
+++ b/pytato/loopy.py
@@ -221,10 +221,12 @@ def call_loopy(translation_unit: "lp.TranslationUnit",
     # {{{ infer types of the translation_unit
 
     for name, ary in bindings.items():
+        if translation_unit[entrypoint].arg_dict[name].dtype not in [lp.auto,
+                                                                     None]:
+            continue
+
         if isinstance(ary, Array):
             translation_unit = lp.add_dtypes(translation_unit, {name: ary.dtype})
-        elif isinstance(ary, prim.Expression):
-            translation_unit = lp.add_dtypes(translation_unit, {name: np.intp})
         else:
             assert isinstance(ary, Number)
             translation_unit = lp.add_dtypes(translation_unit, {name: type(ary)})
@@ -461,6 +463,8 @@ def extend_bindings_with_shape_inference(knl: lp.LoopKernel,
 
         # {{{ respect callee's scalar dtype preference if there exists one
 
+        # TODO: remove this once
+        # https://github.com/inducer/loopy/issues/442 is resolved.
         if (isinstance(val, Number)
                 and knl.arg_dict[var].dtype not in [lp.auto, None]):
             val = knl.arg_dict[var].dtype.numpy_dtype.type(val)

--- a/pytato/loopy.py
+++ b/pytato/loopy.py
@@ -353,27 +353,6 @@ def _get_pt_dim_expr(dim: Union[int, Array]) -> ScalarExpression:
 # }}}
 
 
-# {{{ SizeParamGatherer
-
-from pytato.transform import CombineMapper
-
-
-class SizeParamGatherer(CombineMapper[FrozenSet[SizeParam]]):
-    """
-    Mapper to combine all instances of :class:`pytato.InputArgumentBase` that
-    an array expression depends on.
-    """
-    def combine(self, *args: FrozenSet[SizeParam]
-                ) -> FrozenSet[SizeParam]:
-        from functools import reduce
-        return reduce(lambda a, b: a | b, args, frozenset())
-
-    def map_size_param(self, expr: SizeParam) -> FrozenSet[SizeParam]:
-        return frozenset([expr])
-
-# }}}
-
-
 def extend_bindings_with_shape_inference(knl: lp.LoopKernel,
                                          bindings: PMap[str, ArrayOrScalar]
                                          ) -> Dict[str, ArrayOrScalar]:
@@ -381,6 +360,8 @@ def extend_bindings_with_shape_inference(knl: lp.LoopKernel,
     from loopy.symbolic import get_dependencies as lpy_get_deps
     from loopy.kernel.array import ArrayBase
     from pymbolic.mapper.substitutor import make_subst_func
+    from pytato.transform import SizeParamGatherer
+
     get_size_param_deps = SizeParamGatherer()
 
     lp_size_params: FrozenSet[str] = reduce(frozenset.union,

--- a/pytato/transform.py
+++ b/pytato/transform.py
@@ -333,6 +333,20 @@ class InputGatherer(CombineMapper[FrozenSet[InputArgumentBase]]):
     def map_size_param(self, expr: SizeParam) -> FrozenSet[SizeParam]:
         return frozenset([expr])
 
+
+class SizeParamGatherer(CombineMapper[FrozenSet[SizeParam]]):
+    """
+    Mapper to combine all instances of :class:`pytato.InputArgumentBase` that
+    an array expression depends on.
+    """
+    def combine(self, *args: FrozenSet[SizeParam]
+                ) -> FrozenSet[SizeParam]:
+        from functools import reduce
+        return reduce(lambda a, b: a | b, args, frozenset())
+
+    def map_size_param(self, expr: SizeParam) -> FrozenSet[SizeParam]:
+        return frozenset([expr])
+
 # }}}
 
 

--- a/pytato/transform.py
+++ b/pytato/transform.py
@@ -318,7 +318,7 @@ class SubsetDependencyMapper(DependencyMapper):
 
 class InputGatherer(CombineMapper[FrozenSet[InputArgumentBase]]):
     """
-    Mapper to combine all instances of :class:`pytato.InputArgumentBase` that
+    Mapper to combine all instances of :class:`pytato.array.InputArgumentBase` that
     an array expression depends on.
     """
     def combine(self, *args: FrozenSet[InputArgumentBase]
@@ -338,7 +338,7 @@ class InputGatherer(CombineMapper[FrozenSet[InputArgumentBase]]):
 
 class SizeParamGatherer(CombineMapper[FrozenSet[SizeParam]]):
     """
-    Mapper to combine all instances of :class:`pytato.SizeParam` that
+    Mapper to combine all instances of :class:`pytato.array.SizeParam` that
     an array expression depends on.
     """
     def combine(self, *args: FrozenSet[SizeParam]
@@ -354,7 +354,7 @@ class SizeParamGatherer(CombineMapper[FrozenSet[SizeParam]]):
 
 class WalkMapper(Mapper):
     """
-    A mapper that walks over all the arrays in a :class:`pytato.array.Array`.
+    A mapper that walks over all the arrays in a :class:`pytato.Array`.
 
     Users may override the specific mapper methods in a derived class or
     override :meth:`WalkMapper.visit` and :meth:`WalkMapper.post_visit`.

--- a/pytato/transform.py
+++ b/pytato/transform.py
@@ -43,6 +43,8 @@ __doc__ = """
 
 .. autoclass:: CopyMapper
 .. autoclass:: DependencyMapper
+.. autoclass:: InputGatherer
+.. autoclass:: SizeParamGatherer
 .. autoclass:: SubsetDependencyMapper
 .. autoclass:: WalkMapper
 .. autoclass:: CachedWalkMapper
@@ -336,7 +338,7 @@ class InputGatherer(CombineMapper[FrozenSet[InputArgumentBase]]):
 
 class SizeParamGatherer(CombineMapper[FrozenSet[SizeParam]]):
     """
-    Mapper to combine all instances of :class:`pytato.InputArgumentBase` that
+    Mapper to combine all instances of :class:`pytato.SizeParam` that
     an array expression depends on.
     """
     def combine(self, *args: FrozenSet[SizeParam]

--- a/pytato/utils.py
+++ b/pytato/utils.py
@@ -26,7 +26,7 @@ import numpy as np
 import pymbolic.primitives as prim
 
 from numbers import Number
-from typing import Tuple, List, Union, Callable, Any, Sequence, Dict
+from typing import Tuple, List, Union, Callable, Any, Sequence, Dict, Optional
 from pytato.array import (Array, ShapeType, IndexLambda, SizeParam, ShapeComponent,
                           DtypeOrScalar, ArrayOrScalar)
 from pytato.scalar_expr import (ScalarExpression, IntegralScalarExpression,
@@ -193,7 +193,7 @@ class ShapeExpressionMapper(Mapper):
 
 
 def dim_to_index_lambda_components(expr: ShapeComponent,
-                                   vng: UniqueNameGenerator,
+                                   vng: Optional[UniqueNameGenerator] = None,
                                    ) -> Tuple[ScalarExpression,
                                               Dict[str, SizeParam]]:
     """
@@ -218,6 +218,10 @@ def dim_to_index_lambda_components(expr: ShapeComponent,
     if isinstance(expr, int):
         return expr, {}
 
+    if vng is None:
+        vng = UniqueNameGenerator()
+
+    assert isinstance(vng, UniqueNameGenerator)
     assert isinstance(expr, Array)
     mapper = ShapeExpressionMapper(vng)
     result = mapper(expr)

--- a/run-mypy.sh
+++ b/run-mypy.sh
@@ -1,3 +1,3 @@
 #! /bin/bash
 
-mypy --strict pytato
+mypy --show-error-codes --strict pytato


### PR DESCRIPTION
Why not do it on the loopy end?
- Much more involved on the loopy end, as in order to perform shape inference at a call site the call *must* be a kwarged-call otherwise the argument matching becomes ambiguous. I.e. first teach loopy calls kwargs and then implement shape inference.

What kind of shape expressions are allowed?
- Since the implementation uses ISL to solve quasi-affine equations, it therefore puts a restriction on the shape component expressions, requiring them to be quasi-affine both on the loopy end and the pytato end.


This is smarter than the shape inference done on the host-side loopy ;)  (see https://github.com/inducer/loopy/issues/424)

---
(DRAFT) DO NOT MERGE, because
- [x] Contains commits from #103, so that must go in first.