### PR TITLE
Recurse RHS and only then check if it was stored result

### DIFF
--- a/pytato/target/loopy/codegen.py
+++ b/pytato/target/loopy/codegen.py
@@ -432,20 +432,19 @@ class CodeGenMapper(Mapper):
                     pt_arg = expr.bindings[arg.name]
                     assert isinstance(pt_arg, Array)
 
-                    if pt_arg in state.results and (
-                            isinstance(state.results[pt_arg], StoredResult)):
+                    pt_arg_rec = self.rec(pt_arg, state)
+
+                    if isinstance(pt_arg_rec, StoredResult):
                         # found a stored result corresponding to the argument, use it
-                        stored_result: StoredResult = state.results[  # type: ignore
-                                pt_arg]
-                        name = stored_result.name
+                        name = pt_arg_rec.name
                         params.append(_get_sub_array_ref(pt_arg, name))
-                        depends_on.update(stored_result.depends_on)
+                        depends_on.update(pt_arg_rec.depends_on)
                     else:
                         # did not find a stored result for the sub-expression, store
                         # it and then pass it to the call
                         name = state.var_name_gen("_pt_temp")
                         store_insn_id = add_store(name, pt_arg,
-                                self.rec(pt_arg, state),
+                                pt_arg_rec,
                                 state, output_to_temporary=True,
                                 cgen_mapper=self)
                         depends_on.add(store_insn_id)


### PR DESCRIPTION
For a simple DAG like:

```python
twice = lp.make_kernel(
    "{[i]: 0<=i<n}",
    """
    y[i] = 2*x[i]
    """,
    name="twice")

x = pt.make_placeholder(shape=(10,), dtype=np.float64, name="pt_x")
y = call_loopy(twice, {"x": x})["y"]
z = call_loopy(twice, {"x": y})["y"]
out = call_loopy(twice, {"x": z})["y"]
```

we were generating the following kernel:

```python
   for _pt_temp_1_dim0
↱    _pt_temp_1[_pt_temp_1_dim0] = pt_x[_pt_temp_1_dim0]  {id=_pt_temp_1_store}
│  end _pt_temp_1_dim0
└↱ [__pt_temp_2_dim0]: _pt_temp_2[__pt_temp_2_dim0] = twice(10, [__pt_temp_1_dim0]: _pt_temp_1[__pt_temp_1_dim0])  {id=call_twice_1}
 │ for _pt_temp_0_dim0
↱└   _pt_temp_0[_pt_temp_0_dim0] = _pt_temp_2[_pt_temp_0_dim0]  {id=_pt_temp_0_store}
│  end _pt_temp_0_dim0
└↱ [__pt_temp_3_dim0]: _pt_temp_3[__pt_temp_3_dim0] = twice(10, [__pt_temp_0_dim0]: _pt_temp_0[__pt_temp_0_dim0])  {id=call_twice_0}
 │ for _pt_temp_dim0
↱└   _pt_temp[_pt_temp_dim0] = _pt_temp_3[_pt_temp_dim0]  {id=_pt_temp_store}
│  end _pt_temp_dim0
└↱ [__pt_temp_4_dim0]: _pt_temp_4[__pt_temp_4_dim0] = twice(10, [__pt_temp_dim0]: _pt_temp[__pt_temp_dim0])  {id=call_twice}
 │ for _pt_out_dim0
 └   _pt_out[_pt_out_dim0] = _pt_temp_4[_pt_out_dim0]  {id=_pt_out_store}
   end _pt_out_dim0
```

I.e. way more allocations!

After this fix the generated kernel looks like:

```python
↱  [__pt_temp_dim0]: _pt_temp[__pt_temp_dim0] = twice(10, [_pt_x_dim0]: pt_x[_pt_x_dim0])  {id=call_twice_1}
└↱ [__pt_temp_0_dim0]: _pt_temp_0[__pt_temp_0_dim0] = twice(10, [__pt_temp_dim0_0]: _pt_temp[__pt_temp_dim0_0])  {id=call_twice_0}
↱└ [__pt_temp_1_dim0]: _pt_temp_1[__pt_temp_1_dim0] = twice(10, [__pt_temp_0_dim0_0]: _pt_temp_0[__pt_temp_0_dim0_0])  {id=call_twice}
│  for _pt_out_dim0
└    _pt_out[_pt_out_dim0] = _pt_temp_1[_pt_out_dim0]  {id=_pt_out_store}
   end _pt_out_dim0
```