### PR TITLE
Mimic array.reshape behavior to match that of numpy

### DIFF
--- a/pytato/array.py
+++ b/pytato/array.py
@@ -593,9 +593,15 @@ class Array(Taggable):
         import pytato as pt
         return pt.imag(self)
 
-    def reshape(self, shape: Sequence[int], order: str = "C") -> Array:
+    def reshape(self, *shape: Union[int, Sequence[int]], order: str = "C") -> Array:
         import pytato as pt
-        return pt.reshape(self, shape, order=order)
+        if len(shape) == 1:
+            # handle shape as single argument tuple
+            return pt.reshape(self, shape[0], order=order)
+
+        # type-ignore reason: passed: "Tuple[Union[int, Sequence[int]], ...]";
+        # expected "Union[int, Sequence[int]]"
+        return pt.reshape(self, shape, order=order)  # type: ignore
 
 # }}}
 
@@ -1703,7 +1709,8 @@ def _make_slice(array: Array, starts: Sequence[int], stops: Sequence[int]) -> Ar
     return Slice(array, tuple(starts), tuple(stops))
 
 
-def reshape(array: Array, newshape: Sequence[int], order: str = "C") -> Array:
+def reshape(array: Array, newshape: Union[int, Sequence[int]],
+            order: str = "C") -> Array:
     """
     :param array: array to be reshaped
     :param newshape: shape of the resulting array
@@ -1715,6 +1722,9 @@ def reshape(array: Array, newshape: Sequence[int], order: str = "C") -> Array:
         reshapes of arrays with symbolic shapes not yet implemented.
     """
     from pytools import product
+
+    if isinstance(newshape, int):
+        newshape = newshape,
 
     if newshape.count(-1) > 1:
         raise ValueError("can only specify one unknown dimension")

--- a/test/test_codegen.py
+++ b/test/test_codegen.py
@@ -466,7 +466,8 @@ def test_concatenate(ctx_factory):
                                       (-1, 6),
                                       (4, 9),
                                       (9, -1),
-                                      (36, -1)])
+                                      (36, -1),
+                                      36])
 def test_reshape(ctx_factory, oldshape, newshape):
     cl_ctx = ctx_factory()
     queue = cl.CommandQueue(cl_ctx)
@@ -478,6 +479,9 @@ def test_reshape(ctx_factory, oldshape, newshape):
     x = pt.make_data_wrapper(x_in)
 
     assert_allclose_to_numpy(pt.reshape(x, newshape=newshape), queue)
+    assert_allclose_to_numpy(x.reshape(newshape), queue)
+    if isinstance(newshape, tuple):
+        assert_allclose_to_numpy(x.reshape(*newshape), queue)
 
 
 def test_dict_of_named_array_codegen_avoids_recomputation():


### PR DESCRIPTION
`array.reshape` is more flexible than  `np.reshape`. `array.reshape` can also
take a sequence of ints to be reshaped into along with a single-arg tuple newshape.