### PR TITLE
Fixes a bug in einsum' shape computation

### DIFF
--- a/pytato/array.py
+++ b/pytato/array.py
@@ -902,7 +902,8 @@ class Einsum(Array):
     @property  # type: ignore
     @memoize_method
     def shape(self) -> ShapeType:
-        iaxis_to_len = {}
+        from pytato.utils import are_shape_components_equal
+        iaxis_to_len: Dict[int, ShapeComponent] = {}
 
         for access_descr, arg in zip(self.access_descriptors,
                                      self.args):
@@ -910,7 +911,10 @@ class Einsum(Array):
             for arg_axis_len, axis_op in zip(arg.shape, access_descr):
                 if isinstance(axis_op, ElementwiseAxis):
                     if axis_op.dim in iaxis_to_len:
-                        assert arg.shape[axis_op.dim] == arg_axis_len
+                        # check that the accumulated shape-dim matches with the
+                        # current arg's axis len
+                        assert are_shape_components_equal(iaxis_to_len[axis_op.dim],
+                                                          arg_axis_len)
                     else:
                         iaxis_to_len[axis_op.dim] = arg_axis_len
                 elif isinstance(axis_op, ReductionAxis):

--- a/test/test_codegen.py
+++ b/test/test_codegen.py
@@ -849,6 +849,9 @@ def test_reductions(ctx_factory, axis, redn, shape):
 
                                              (" ij ->  ",  # np.sum
                                               [(10, 4)]),
+                                             ("dij,ej,ej,dej->ei",
+                                              [(2, 10, 10), (100, 10),
+                                               (100, 10), (2, 100, 10)]),
                                              ]))
 def test_einsum(ctx_factory, spec, argshapes):
     ctx = ctx_factory()


### PR DESCRIPTION
check that the argument axis length corresponding to the same output axis
matches with the previously recorded one.


The provided test fails on `main`.