### PR TITLE
Raise IndexError for OOB access

### DIFF
--- a/pytato/array.py
+++ b/pytato/array.py
@@ -439,7 +439,7 @@ class Array(Taggable):
                 [slice(None, None, None)] * (self.ndim - len(slice_spec)))
 
         if len(slice_spec_expanded) > self.ndim:
-            raise ValueError("too many dimensions in index")
+            raise IndexError("too many dimensions in index")
 
         for i, elem in enumerate(slice_spec_expanded):
             if isinstance(elem, slice):
@@ -1720,7 +1720,7 @@ def _make_slice(array: Array, starts: Sequence[int], stops: Sequence[int]) -> Ar
 
         ubound: int = cast(int, array.shape[i])
         if not (0 <= start < ubound):
-            raise ValueError("index '%d' of 'begin' out of bounds" % i)
+            raise IndexError("index '%d' of 'begin' out of bounds" % i)
 
         if not (start <= stop <= ubound):
             raise ValueError("index '%d' of 'size' out of bounds" % i)

--- a/test/test_pytato.py
+++ b/test/test_pytato.py
@@ -81,10 +81,10 @@ def test_slice_input_validation():
     a[0, 0]
     a[0, 0, 0]
 
-    with pytest.raises(ValueError):
+    with pytest.raises(IndexError):
         a[0, 0, 0, 0]
 
-    with pytest.raises(ValueError):
+    with pytest.raises(IndexError):
         a[10]
 
 


### PR DESCRIPTION
Mimics numpy as:

```python
>>> a = np.random.rand(10)
>>> a[10]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
IndexError: index 10 is out of bounds for axis 0 with size 10
>>> a[0, 0]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
IndexError: too many indices for array: array is 1-dimensional, but 2 were indexed
```