### PR TITLE
Define pt.Array.copy

### DIFF
--- a/pytato/array.py
+++ b/pytato/array.py
@@ -723,6 +723,18 @@ class NamedArray(Array):
         self._container = container
         self.name = name
 
+    # type-ignore reason: `copy` signature incompatible with super-class
+    def copy(self, *,  # type: ignore[override]
+             container: Optional[AbstractResultWithNamedArrays] = None,
+             name: Optional[str] = None,
+             tags: Optional[TagsType] = None) -> NamedArray:
+        container = self._container if container is None else container
+        name = self.name if name is None else name
+        tags = self.tags if tags is None else tags
+        return type(self)(container=container,
+                          name=name,
+                          tags=tags)
+
     @property
     def expr(self) -> Array:
         if isinstance(self._container, DictOfNamedArrays):

--- a/pytato/loopy.py
+++ b/pytato/loopy.py
@@ -124,6 +124,19 @@ class LoopyCallResult(NamedArray):
             tags: TagsType = frozenset()) -> None:
         super().__init__(loopy_call, name, tags=tags)
 
+    # type-ignore reason: `copy` signature incompatible with super-class
+    def copy(self, *,  # type: ignore[override]
+             loopy_call: Optional[AbstractResultWithNamedArrays] = None,
+             name: Optional[str] = None,
+             tags: Optional[TagsType] = None) -> LoopyCallResult:
+        loopy_call = self._container if loopy_call is None else loopy_call
+        name = self.name if name is None else name
+        tags = self.tags if tags is None else tags
+        assert isinstance(loopy_call, LoopyCall)
+        return LoopyCallResult(loopy_call=loopy_call,
+                               name=name,
+                               tags=tags)
+
     def expr(self) -> Array:
         raise ValueError("Expressions for results of loopy functions aren't defined")
 

--- a/test/test_pytato.py
+++ b/test/test_pytato.py
@@ -253,6 +253,19 @@ def test_call_loopy_shape_inference():
     # }}}
 
 
+def test_tagging_array():
+    from pytools.tag import Tag
+
+    class BestArrayTag(Tag):
+        """
+        Best array known to humankind.
+        """
+
+    x = pt.make_placeholder(shape=(42, 1729), dtype=float, name="x")
+    y = x.tagged(BestArrayTag())
+    assert any(isinstance(tag, BestArrayTag) for tag in y.tags)
+
+
 if __name__ == "__main__":
     if len(sys.argv) > 1:
         exec(sys.argv[1])


### PR DESCRIPTION
Test shipped with this patch fails on `main` with:
```
self = <pytato.array.Placeholder object at 0x7f5108c53640>, kwargs = {'tags': frozenset({test_tagging_array.<locals>.BestArrayTag()})}                
                                                                                                                                                      
    def copy(self: T_co, **kwargs: Any) -> T_co:                                                                                                      
        """                                                                                                                                           
        Returns of copy of *self* with the specified tags. This method                                                                                
        should be overridden by subclasses.                                                                                                           
        """                                                                                                                                           
>       raise NotImplementedError("The copy function is not implemented.")                                                                            
E       NotImplementedError: The copy function is not implemented.                                                                                    
                                                                                                                                                      
../../lib/python3.8/site-packages/pytools/tag.py:221: NotImplementedError 
```