### PR TITLE
Turn off implicit numpy-array handling in generated loopy

### DIFF
--- a/pytato/target/loopy/codegen.py
+++ b/pytato/target/loopy/codegen.py
@@ -859,7 +859,7 @@ def generate_loopy(result: Union[Array, DictOfNamedArrays, Dict[str, Array]],
     compute_order = preproc_result.compute_order
 
     if options is None and result_is_dict:
-        options = lp.Options(return_dict=True)
+        options = lp.Options(return_dict=True, no_numpy=True)
 
     state = get_initial_codegen_state(target, options)
 


### PR DESCRIPTION
For a moderate cost savings in the wrapper.