### PR TITLE
Expose some more classes under pytato module

### DIFF
--- a/pytato/__init__.py
+++ b/pytato/__init__.py
@@ -26,7 +26,12 @@ THE SOFTWARE.
 
 from pytato.array import (
         Array, AbstractResultWithNamedArrays, DictOfNamedArrays, Placeholder,
-        IndexLambda, NamedArray, DataWrapper, InputArgumentBase,
+        IndexLambda, NamedArray, DataWrapper, InputArgumentBase, Reshape,
+        Einsum, MatrixProduct, Stack, Concatenate, AxisPermutation,
+        IndexBase, Roll, IndexRemappingBase, BasicIndex,
+        AdvancedIndexInContiguousAxes, AdvancedIndexInNoncontiguousAxes,
+        SizeParam,
+
 
         make_dict_of_named_arrays,
         make_placeholder, make_size_param, make_data_wrapper,
@@ -69,7 +74,11 @@ import pytato.transform as transform
 __all__ = (
         "Array", "AbstractResultWithNamedArrays", "DictOfNamedArrays",
         "Placeholder", "IndexLambda", "NamedArray", "LoopyCall",
-        "DataWrapper", "InputArgumentBase",
+        "DataWrapper", "InputArgumentBase", "Reshape", "Einsum",
+        "MatrixProduct", "Stack", "Concatenate", "AxisPermutation",
+        "IndexBase", "Roll", "IndexRemappingBase",
+        "AdvancedIndexInContiguousAxes", "AdvancedIndexInNoncontiguousAxes",
+        "BasicIndex", "SizeParam",
 
         "make_dict_of_named_arrays", "make_placeholder", "make_size_param",
         "make_data_wrapper", "einsum",


### PR DESCRIPTION
Wanted to write a mapper not within pytato module and `pt.TypeName` is quite handy for specifying type names.