### PR TITLE
Implements DimToLoopyInameTag

### DIFF
--- a/pytato/tags.py
+++ b/pytato/tags.py
@@ -12,6 +12,7 @@ Pre-Defined Tags
 .. autoclass:: Named
 .. autoclass:: PrefixNamed
 .. autoclass:: AssumeNonNegative
+.. autoclass:: DimToLoopyInameTag
 """
 
 
@@ -104,3 +105,23 @@ class AssumeNonNegative(Tag):
     :class:`~pytato.target.Target` that all entries of the tagged array are
     non-negative.
     """
+
+
+# {{{ loopy-target specific metadata
+
+@tag_dataclass
+class DimToLoopyInameTag(Tag):
+    """
+    A tag that can be attached to :class:`~pytato.array.Axis`. If the array
+    whose axis is tagged with this tag is allocated, then the iname responsible
+    for indexing the axis in the allocation instruction would be tagged with
+    :attr:`iname_tag`.
+
+    .. attribute:: iname_tag
+
+        The tag that :class:`loopy.kernel.data.Iname` would be tagged with
+        for the iname indexing the axis.
+    """
+    iname_tag: Tag
+
+# }}}

--- a/pytato/target/loopy/codegen.py
+++ b/pytato/target/loopy/codegen.py
@@ -46,7 +46,8 @@ from pytato.transform import Mapper
 from pytato.scalar_expr import ScalarExpression
 from pytato.codegen import preprocess, normalize_outputs, SymbolicIndex
 from pytato.loopy import LoopyCall
-from pytato.tags import ImplStored, _BaseNameTag, Named, PrefixNamed
+from pytato.tags import (ImplStored, _BaseNameTag, Named, PrefixNamed,
+                         DimToLoopyInameTag)
 
 # set in doc/conf.py
 if getattr(sys, "PYTATO_BUILDING_SPHINX_DOCS", False):
@@ -813,6 +814,14 @@ def add_store(name: str, expr: Array, result: ImplementedResult,
         kernel = kernel.copy(args=kernel.args + [arg],
                 domains=kernel.domains + [domain],
                 instructions=kernel.instructions + [insn])
+
+    # {{{ attach iname tags
+
+    for axis, iname in zip(expr.axes, inames):
+        for tag in axis.tags_of_type(DimToLoopyInameTag):
+            kernel = lp.tag_inames(kernel, {iname: tag.iname_tag})
+
+    # }}}
 
     state.update_kernel(kernel)
     return insn_id

--- a/test/testlib.py
+++ b/test/testlib.py
@@ -4,6 +4,7 @@ import operator
 import pyopencl as cl
 import numpy as np
 import pytato as pt
+from pytools.tag import Tag
 from pytato.transform import Mapper
 from pytato.array import (Array, Placeholder, Stack, Roll,
                           AxisPermutation, DataWrapper, Reshape,
@@ -221,6 +222,22 @@ def make_random_dag(rdagc: RandomDAGContext) -> Any:
     rdagc.past_results.append(result)
 
     return result
+
+# }}}
+
+
+# {{{ tags used only by the regression tests
+
+class FooInameTag(Tag):
+    """
+    foo
+    """
+
+
+class BarInameTag(Tag):
+    """
+    bar
+    """
 
 # }}}
 


### PR DESCRIPTION
Draft because:
- [x] Requires array axes to be taggable via #170 