### PR TITLE
Preserve High-Level Info in the lowered pymbolic expressions

### DIFF
--- a/doc/design.rst
+++ b/doc/design.rst
@@ -54,6 +54,11 @@ Computation and Results
     with an integral :attr:`Array.dtype` (i.e. having ``dtype.kind == "i"``).
     Such an expression marks the boundary between eager and lazy evaluation.
 
+-   :attr:`Array.shape` is required to be an affine expression in terms of the
+    instances of :class:`~pytato.array.SizeParam` in the computation graph. This
+    permits shape inference to use Presburger arithmetic, meaning that shape
+    inference is always decidable.
+
 -   There is (deliberate) overlap in what various expression nodes can
     express, e.g.
 

--- a/test/test_codegen.py
+++ b/test/test_codegen.py
@@ -927,7 +927,7 @@ def test_arguments_passing_to_loopy_kernel_for_non_dependent_vars(ctx_factory):
     _, (out,) = pt.generate_loopy(0 * x)(cq)
 
     assert out.shape == (3, 3)
-    np.testing.assert_allclose(out.get(), 0)
+    np.testing.assert_allclose(out, 0)
 
 
 def test_call_loopy_shape_inference1(ctx_factory):


### PR DESCRIPTION
Pymbolic's `Expression.(__(r?)add__|__(r?)sub__|__(r?)mul__)` can lose the
high-level information of expression as seen in the example below.

```python
>>> from pymbolic import var
>>> x = var("x")
>>> x + 0
Variable('x')
>>> x * 1
Variable('x')
```

---
Also includes 2 commits that help pass the CI.
