### PR TITLE
Propagate axis tags to loopy iname tags

### DIFF
--- a/test/testlib.py
+++ b/test/testlib.py
@@ -8,6 +8,7 @@ from pytato.transform import Mapper
 from pytato.array import (Array, Placeholder, Stack, Roll,
                           AxisPermutation, DataWrapper, Reshape,
                           Concatenate)
+from pytools.tag import Tag
 
 
 # {{{ tools for comparison to numpy
@@ -219,6 +220,28 @@ def make_random_dag(rdagc: RandomDAGContext) -> Any:
     rdagc.past_results.append(result)
 
     return result
+
+# }}}
+
+
+# {{{ tags used only by the regression tests
+
+class FooInameTag(Tag):
+    """
+    foo
+    """
+
+
+class BarInameTag(Tag):
+    """
+    bar
+    """
+
+
+class BazInameTag(Tag):
+    """
+    baz
+    """
 
 # }}}
 


### PR DESCRIPTION
Propagate all `pt.Array.axis` tags as iname tags.