### PR TITLE
Rewrite `isinstance(x, int)` -> `isinstance(x, Integral)`

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -34,3 +34,7 @@ intersphinx_mapping = {
 
 import sys
 sys.PYTATO_BUILDING_SPHINX_DOCS = True
+
+nitpick_ignore_regex = [
+    ["py:class", r"numpy.(u?)int[\d]+"],
+]

--- a/pytato/array.py
+++ b/pytato/array.py
@@ -165,7 +165,8 @@ from pytools import memoize_method
 from pytools.tag import Tag, Taggable, TagsType
 
 from pytato.scalar_expr import (ScalarType, SCALAR_CLASSES,
-                                ScalarExpression)
+                                ScalarExpression, IntegralT,
+                                INT_CLASSES)
 import re
 from pyrsistent import pmap, PMap
 
@@ -196,7 +197,7 @@ ArrayT = TypeVar("ArrayT", bound="Array")
 
 # {{{ shape
 
-ShapeComponent = Union[int, "Array"]
+ShapeComponent = Union[IntegralT, "Array"]
 ShapeType = Tuple[ShapeComponent, ...]
 ConvertibleToShape = Union[
     ShapeComponent,
@@ -235,10 +236,10 @@ def normalize_shape(
                                               "a non-SizeParam array.")
             # TODO: Check affine-ness of the array expression.
         else:
-            if not isinstance(s, int):
+            if not isinstance(s, INT_CLASSES):
                 raise TypeError("array dimension can be an int or pytato.Array. "
                                 f"Got {type(s)}.")
-            assert isinstance(s, int)
+            assert isinstance(s, INT_CLASSES)
             if s < 0:
                 raise ValueError(f"size parameter must be nonnegative (got '{s}')")
 
@@ -257,7 +258,7 @@ def normalize_shape(
 # {{{ array inteface
 
 ConvertibleToIndexExpr = Union[int, slice, "Array", None, EllipsisType]
-IndexExpr = Union[int, "NormalizedSlice", "Array", None, EllipsisType]
+IndexExpr = Union[IntegralT, "NormalizedSlice", "Array", None, EllipsisType]
 DtypeOrScalar = Union[_dtype_any, ScalarType]
 ArrayOrScalar = Union["Array", ScalarType]
 
@@ -303,7 +304,7 @@ class NormalizedSlice:
     """
     start: ShapeComponent
     stop: ShapeComponent
-    step: int
+    step: IntegralT
 
 
 @dataclass(eq=True, frozen=True)
@@ -1378,7 +1379,8 @@ class BasicIndex(IndexBase):
     @property
     def shape(self) -> ShapeType:
         assert len(self.indices) == self.array.ndim
-        assert all(isinstance(idx, (NormalizedSlice, int)) for idx in self.indices)
+        assert all(isinstance(idx, (NormalizedSlice, INT_CLASSES))
+                   for idx in self.indices)
 
         from pytato.utils import _normalized_slice_len
         return tuple(_normalized_slice_len(idx)
@@ -1822,7 +1824,7 @@ def reshape(array: Array, newshape: Union[int, Sequence[int]],
     """
     from pytools import product
 
-    if isinstance(newshape, int):
+    if isinstance(newshape, INT_CLASSES):
         newshape = newshape,
 
     if newshape.count(-1) > 1:
@@ -1831,7 +1833,7 @@ def reshape(array: Array, newshape: Union[int, Sequence[int]],
     if newshape.count(-1) == 1 and newshape.count(0) > 0:
         raise ValueError(f"cannot reshape {array.shape} into {newshape}")
 
-    if not all(isinstance(axis_len, int) for axis_len in array.shape):
+    if not all(isinstance(axis_len, INT_CLASSES) for axis_len in array.shape):
         raise ValueError("reshape of arrays with symbolic lengths not allowed")
 
     if order != "C":
@@ -1840,7 +1842,7 @@ def reshape(array: Array, newshape: Union[int, Sequence[int]],
     newshape_explicit = []
 
     for new_axislen in newshape:
-        if not isinstance(new_axislen, int):
+        if not isinstance(new_axislen, INT_CLASSES):
             raise ValueError("Symbolic reshapes not allowed.")
 
         if new_axislen < -1:
@@ -2004,7 +2006,7 @@ def eye(N: int, M: Optional[int] = None, k: int = 0,  # noqa: N803
     if M < 0 or N < 0:
         raise ValueError("Negative dimension lengths not allowed.")
 
-    if not isinstance(k, int):
+    if not isinstance(k, INT_CLASSES):
         raise ValueError(f"k must be int, got {type(k)}.")
 
     return IndexLambda(parse(f"1 if ((_1 - _0) == {k}) else 0"),

--- a/pytato/loopy.py
+++ b/pytato/loopy.py
@@ -33,7 +33,8 @@ from typing import (Dict, Optional, Any, Iterator, FrozenSet, Union, Sequence,
 from numbers import Number
 from pytato.array import (AbstractResultWithNamedArrays, Array, ShapeType,
                           NamedArray, ArrayOrScalar, SizeParam, AxesT)
-from pytato.scalar_expr import SubstitutionMapper, ScalarExpression, EvaluationMapper
+from pytato.scalar_expr import (SubstitutionMapper, ScalarExpression,
+                                EvaluationMapper, IntegralT)
 from pytools import memoize_method
 from pytools.tag import TagsType
 from pyrsistent import PMap, pmap
@@ -368,7 +369,7 @@ def _pt_var_to_global_namespace(name: Optional[str]) -> str:
     return f"_pt_{name}"
 
 
-def _get_pt_dim_expr(dim: Union[int, Array]) -> ScalarExpression:
+def _get_pt_dim_expr(dim: Union[IntegralT, Array]) -> ScalarExpression:
     from pytato.utils import dim_to_index_lambda_components
     from pymbolic.mapper.substitutor import substitute
     dim_expr, dim_bnds = dim_to_index_lambda_components(dim)

--- a/pytato/reductions.py
+++ b/pytato/reductions.py
@@ -29,7 +29,7 @@ THE SOFTWARE.
 
 from typing import Optional, Tuple, Union, Sequence, Dict, List
 from pytato.array import ShapeType, Array, make_index_lambda
-from pytato.scalar_expr import ScalarExpression, Reduce
+from pytato.scalar_expr import ScalarExpression, Reduce, INT_CLASSES
 import pymbolic.primitives as prim
 
 # {{{ docs
@@ -69,7 +69,7 @@ def _normalize_reduction_axes(
     if reduction_axes is None:
         return (), tuple(range(len(shape)))
 
-    if isinstance(reduction_axes, int):
+    if isinstance(reduction_axes, INT_CLASSES):
         reduction_axes = reduction_axes,
 
     if not isinstance(reduction_axes, tuple):
@@ -105,7 +105,7 @@ def _get_reduction_indices_bounds(shape: ShapeType,
     n_redn_dims = 0
     for idim, axis_len in enumerate(shape):
         if idim in axes:
-            if not isinstance(axis_len, int):
+            if not isinstance(axis_len, INT_CLASSES):
                 # TODO: add bindings for shape array expressions
                 raise NotImplementedError("Parametric shapes for reduction axes"
                                           " not yet supported.")

--- a/pytato/scalar_expr.py
+++ b/pytato/scalar_expr.py
@@ -63,7 +63,12 @@ __doc__ = """
 
 # {{{ scalar expressions
 
-IntegralScalarExpression = Union[int, prim.Expression]
+IntegralT = Union[int, np.int8, np.int16, np.int32, np.int64, np.uint8,
+                  np.uint16, np.uint32, np.uint64]
+BoolT = Union[bool, np.bool8]
+INT_CLASSES = (int, np.int8, np.int16, np.int32, np.int64, np.uint8,
+               np.uint16, np.uint32, np.uint64)
+IntegralScalarExpression = Union[IntegralT, prim.Expression]
 ScalarType = Union[Number, int, np.bool_, bool]
 ScalarExpression = Union[ScalarType, prim.Expression]
 SCALAR_CLASSES = prim.VALID_CONSTANT_CLASSES

--- a/pytato/target/loopy/codegen.py
+++ b/pytato/target/loopy/codegen.py
@@ -43,7 +43,7 @@ from pytato.array import (Array, DictOfNamedArrays, ShapeType, IndexLambda,
 from pytato.target import BoundProgram
 from pytato.target.loopy import LoopyPyOpenCLTarget, LoopyTarget
 from pytato.transform import Mapper
-from pytato.scalar_expr import ScalarExpression
+from pytato.scalar_expr import ScalarExpression, INT_CLASSES
 from pytato.codegen import preprocess, normalize_outputs, SymbolicIndex
 from pytato.loopy import LoopyCall
 from pytato.tags import ImplStored, _BaseNameTag, Named, PrefixNamed
@@ -660,7 +660,7 @@ def shape_to_scalar_expression(shape: ShapeType,
     shape_context = PersistentExpressionContext(state)
     result: List[ScalarExpression] = []
     for component in shape:
-        if isinstance(component, int):
+        if isinstance(component, INT_CLASSES):
             result.append(component)
         else:
             assert isinstance(component, Array)

--- a/pytato/utils.py
+++ b/pytato/utils.py
@@ -34,7 +34,7 @@ from pytato.array import (Array, ShapeType, IndexLambda, SizeParam, ShapeCompone
                           AdvancedIndexInNoncontiguousAxes,
                           ConvertibleToIndexExpr, IndexExpr, NormalizedSlice)
 from pytato.scalar_expr import (ScalarExpression, IntegralScalarExpression,
-                                SCALAR_CLASSES)
+                                SCALAR_CLASSES, INT_CLASSES, BoolT)
 from pytools import UniqueNameGenerator
 from pytato.transform import Mapper
 
@@ -245,7 +245,7 @@ def dim_to_index_lambda_components(expr: ShapeComponent,
         >>> bnds  # doctest: +ELLIPSIS
         {'_in': <pytato.array.SizeParam ...>}
     """
-    if isinstance(expr, int):
+    if isinstance(expr, INT_CLASSES):
         return expr, {}
 
     if vng is None:
@@ -336,11 +336,11 @@ def _get_size_params_assumptions_bset(space: isl.Space) -> isl.BasicSet:
     return bset
 
 
-def _is_non_negative(expr: ShapeComponent) -> bool:
+def _is_non_negative(expr: ShapeComponent) -> BoolT:
     """
     Returns *True* iff it can be proven that ``expr >= 0``.
     """
-    if isinstance(expr, int):
+    if isinstance(expr, INT_CLASSES):
         return expr >= 0
 
     assert isinstance(expr, Array) and expr.shape == ()
@@ -354,7 +354,7 @@ def _is_non_negative(expr: ShapeComponent) -> bool:
             <= _get_size_params_assumptions_bset(space))
 
 
-def _is_non_positive(expr: ShapeComponent) -> bool:
+def _is_non_positive(expr: ShapeComponent) -> BoolT:
     """
     Returns *True* iff it can be proven that ``expr <= 0``.
     """
@@ -370,7 +370,7 @@ def _normalize_slice(slice_: slice,
     start, stop, step = slice_.start, slice_.stop, slice_.step
     if step is None:
         step = 1
-    if not isinstance(step, int):
+    if not isinstance(step, INT_CLASSES):
         raise ValueError(f"slice step must be an int or 'None' (got a {type(step)})")
     if step == 0:
         raise ValueError("slice step cannot be zero")
@@ -385,7 +385,7 @@ def _normalize_slice(slice_: slice,
     if start is None:
         start = default_start
     else:
-        if isinstance(axis_len, int):
+        if isinstance(axis_len, INT_CLASSES):
             if -axis_len <= start < axis_len:
                 start = start % axis_len
             elif start >= axis_len:
@@ -404,7 +404,7 @@ def _normalize_slice(slice_: slice,
     if stop is None:
         stop = default_stop
     else:
-        if isinstance(axis_len, int):
+        if isinstance(axis_len, INT_CLASSES):
             if -axis_len <= stop < axis_len:
                 stop = stop % axis_len
             elif stop >= axis_len:
@@ -496,7 +496,7 @@ def _index_into(ary: Array, indices: Tuple[ConvertibleToIndexExpr, ...]) -> Arra
     for i, idx in enumerate(indices):
         if isinstance(idx, slice):
             pass
-        elif isinstance(idx, int):
+        elif isinstance(idx, INT_CLASSES):
             if not (_is_non_negative(idx + ary.shape[i])
                     and _is_non_negative(ary.shape[i] - 1 - idx)):
                 raise IndexError(f"{idx} is out of bounds for axis {i}")


### PR DESCRIPTION
This allows np.int*-types as valid input types as well.