### PR TITLE
Use `np.errstate` to raise on numpy errors, instead of a warning filter

### DIFF
--- a/test/test_codegen.py
+++ b/test/test_codegen.py
@@ -1333,11 +1333,9 @@ def test_random_dag_against_numpy(ctx_factory):
 
     from testlib import RandomDAGContext, make_random_dag
     axis_len = 5
-    from warnings import filterwarnings, catch_warnings
-    with catch_warnings():
-        # We'd like to know if Numpy divides by zero.
-        filterwarnings("error")
 
+    # We'd like to know if Numpy divides by zero.
+    with np.errstate(all="raise"):
         for i in range(50):
             print(i)  # progress indicator for somewhat slow test
 


### PR DESCRIPTION
The previous way broke https://github.com/inducer/pytools/pull/120, which (deliberately) introduced a warning to be raised, which the code being removed turned into an exception.