### PR TITLE
Add a test application: Trace an FFT

### DIFF
--- a/pytato/target/loopy/codegen.py
+++ b/pytato/target/loopy/codegen.py
@@ -746,8 +746,9 @@ def _generate_name_for_temp(expr: Array, state: CodeGenState) -> str:
             name_tag, = expr.tags_of_type(Named)
             if state.var_name_gen.is_name_conflicting(name_tag.name):
                 raise ValueError(f"Cannot assign the name {name_tag.name} to the"
-                                 f" temporary corresponding to {expr} as it is"
-                                 " referring a loopy kernel argument.")
+                                 f" temporary corresponding to {expr} as it "
+                                 "conflicts with an existing name. ")
+            state.var_name_gen.add_name(name_tag.name)
             return name_tag.name
         elif expr.tags_of_type(PrefixNamed):
             prefix_tag, = expr.tags_of_type(PrefixNamed)

--- a/test/test_apps.py
+++ b/test/test_apps.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python
+
+__copyright__ = """Copyright (C) 2020 Andreas Kloeckner
+Copyright (C) 2022 Isuru Fernando
+"""
+
+__license__ = """
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+"""
+
+import sys
+import numpy as np
+import numpy.linalg as la
+
+import pyopencl as cl
+
+import pytato as pt
+from pymbolic.mapper import IdentityMapper as PymbolicIdentityMapper
+from pytato.transform import CopyMapper, WalkMapper
+
+from pyopencl.tools import (  # noqa: F401
+        pytest_generate_tests_for_pyopencl as pytest_generate_tests)
+
+from pytools.tag import Tag, tag_dataclass
+
+
+# {{{ Trace an FFT
+
+# A failed-for-now experiment: Trace through an FFT to generate code.
+# It might as well live on as a reasonably complex test.
+
+@tag_dataclass
+class FFTIntermediate(Tag):
+    level: int
+
+
+class FFTVectorGatherer(WalkMapper):
+    def __init__(self, n):
+        self.n = n
+        self.level_to_arrays = {}
+        super().__init__()
+
+    def map_index_lambda(self, expr):
+        tags = expr.tags_of_type(FFTIntermediate)
+        if tags:
+            ffti_tag, = tags
+            self.level_to_arrays.setdefault(
+                    ffti_tag.level, set()).add(expr)
+        super().map_index_lambda(expr)
+
+
+class ConstantSizer(PymbolicIdentityMapper):
+    def map_constant(self, expr):
+        if isinstance(expr, float):
+            return np.float64(expr)
+        elif isinstance(expr, complex):
+            return np.complex128(expr)
+        else:
+            return expr
+
+
+class FFTRealizationMapper(CopyMapper):
+    def __init__(self, fft_vec_gatherer):
+        super().__init__()
+
+        self.fft_vec_gatherer = fft_vec_gatherer
+
+        self.old_array_to_new_array = {}
+        levels = sorted(fft_vec_gatherer.level_to_arrays, reverse=True)
+
+        lev = 0
+        arrays = fft_vec_gatherer.level_to_arrays[lev]
+        self.finalized = False
+
+        for lev in levels:
+            arrays = fft_vec_gatherer.level_to_arrays[lev]
+            rec_arrays = [self.rec(ary) for ary in arrays]
+            # reset cache so that the partial subs are not stored
+            self._cache = {}
+            lev_array = pt.concatenate(rec_arrays, axis=0)
+            assert lev_array.shape == (fft_vec_gatherer.n,)
+
+            startidx = 0
+            for array in arrays:
+                size = array.shape[0]
+                sub_array = lev_array[startidx:startidx+size]
+                startidx += size
+                self.old_array_to_new_array[array] = sub_array
+
+            assert startidx == fft_vec_gatherer.n
+        self.finalized = True
+
+    def map_index_lambda(self, expr):
+        tags = expr.tags_of_type(FFTIntermediate)
+        if tags:
+            if self.finalized or expr in self.old_array_to_new_array:
+                return self.old_array_to_new_array[expr]
+
+        return super().map_index_lambda(
+                expr.copy(expr=ConstantSizer()(expr.expr)))
+
+    def map_concatenate(self, expr):
+        from pytato.tags import ImplStored, PrefixNamed
+        return super().map_concatenate(expr).tagged(
+                (ImplStored(), PrefixNamed("concat")))
+
+
+def test_trace_fft(ctx_factory):
+    ctx = ctx_factory()
+    queue = cl.CommandQueue(ctx)
+
+    n = 33
+    x = pt.make_placeholder("x", n, dtype=np.complex128)
+
+    from pymbolic.algorithm import fft
+    result = fft(x, custom_np=pt,
+            wrap_intermediate_with_level=(
+                lambda level, ary: ary.tagged(FFTIntermediate(level))))
+
+    fft_vec_gatherer = FFTVectorGatherer(n)
+    fft_vec_gatherer(result)
+
+    mapper = FFTRealizationMapper(fft_vec_gatherer)
+
+    result = mapper(result)
+
+    prg = pt.generate_loopy(result).program
+
+    x = np.random.randn(n).astype(np.complex128)
+    evt, (result,) = prg(queue, x=x)
+
+    ref_result = fft(x)
+
+    print(la.norm(result-ref_result))
+    assert la.norm(result-ref_result) < 1e-14
+
+# }}}
+
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1:
+        exec(sys.argv[1])
+    else:
+        from pytest import main
+        main([__file__])
+
+# vim: fdm=marker

--- a/test/test_codegen.py
+++ b/test/test_codegen.py
@@ -59,6 +59,18 @@ def test_basic_codegen(ctx_factory):
     assert (out == x_in * x_in).all()
 
 
+def test_named_clash(ctx_factory):
+    x = pt.make_placeholder("x", (5,), np.int64)
+
+    from pytato.tags import ImplStored, Named
+    expr = (
+            (2*x).tagged((Named("xx"), ImplStored()))
+            + (3*x).tagged((Named("xx"), ImplStored())))
+
+    with pytest.raises(ValueError):
+        pt.generate_loopy(expr)
+
+
 def test_scalar_placeholder(ctx_factory):
     ctx = ctx_factory()
     queue = cl.CommandQueue(ctx)


### PR DESCRIPTION
cc @isuruf 

This also fixes an actual bug: You could tag multiple distinct values as `Named` the same thing, and nothing would complain.

Read commit-by-commit.