### PR TITLE
Add, test a `CommunicationBatch` tag

### DIFF
--- a/pytato/tags.py
+++ b/pytato/tags.py
@@ -9,9 +9,11 @@ Pre-Defined Tags
 .. autoclass:: Named
 .. autoclass:: PrefixNamed
 .. autoclass:: AssumeNonNegative
+.. autoclass:: CommunicationBatch
 """
 
 
+from typing import Hashable
 from pytools.tag import Tag, UniqueTag, tag_dataclass
 
 
@@ -101,3 +103,20 @@ class AssumeNonNegative(Tag):
     :class:`~pytato.target.Target` that all entries of the tagged array are
     non-negative.
     """
+
+
+@tag_dataclass
+class CommunicationBatch(UniqueTag):
+    """
+    A tag attached to :class:`~pytato.DistributedSend` or
+    :class:`~pytato.DistributedRecv` to indicate that all communication of each
+    direction (send/receive) with the same :attr:`batch_tag` should be carried
+    out in a single batch.
+
+    .. attribute:: batch_tag
+
+        A hashable identifier for the communication batch.
+    """
+    # FIXME: For now, "batching" just results in fewer partitions. The data
+    # is still being sent with separate send/recv operations.
+    batch_tag: Hashable

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     python_requires="~=3.8",
     install_requires=[
         "loopy>=2020.2",
-        "pytools>=2021.1",
+        "pytools>=2022.1.2",
         "pyrsistent"
         ],
     package_data={"pytato": ["py.typed"]},

--- a/test/testlib.py
+++ b/test/testlib.py
@@ -244,6 +244,10 @@ def make_random_dag(rdagc: RandomDAGContext) -> Any:
 # }}}
 
 
+class MY_COMM_BATCH:  # noqa: N801
+    pass
+
+
 # {{{ tags used only by the regression tests
 
 class FooInameTag(Tag):


### PR DESCRIPTION
Needs:

- [x] https://github.com/inducer/pytools/pull/122
- [x] A `pytools` release: https://pypi.org/project/pytools/2022.1.2/
- [x] Needs https://github.com/inducer/loopy/pull/580

As shown in the test, this can help significantly reduce the number of parts. (cf. https://github.com/inducer/pytato/issues/272#issuecomment-1071637220) Once this is in, we can start using it from grudge, which should be, more or less, a one-liner.

cc @kaushikcfd @matthiasdiener 