### PR TITLE
Implements a distributed partitioner that is lazier than `find_distributed_partitions`

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -26,6 +26,7 @@ intersphinx_mapping = {
     "https://documen.tician.de/loopy/": None,
     "https://documen.tician.de/sumpy/": None,
     "https://documen.tician.de/islpy/": None,
+    "https://pyrsistent.readthedocs.io/en/latest/": None,
 }
 
 import sys
@@ -33,4 +34,6 @@ sys.PYTATO_BUILDING_SPHINX_DOCS = True
 
 nitpick_ignore_regex = [
     ["py:class", r"numpy.(u?)int[\d]+"],
+    ["py:class", r"pyrsistent.typing.(.+)"],
+
 ]

--- a/examples/demo_distributed_node_duplication.py
+++ b/examples/demo_distributed_node_duplication.py
@@ -1,0 +1,37 @@
+"""
+An example to demonstrate the behavior of
+:func:`pytato.find_distrbuted_partition`. One of the key characteristic of the
+partitioning routine is to recompute expressions that appear in the multiple
+partitions but are not materialized.
+"""
+import pytato as pt
+import numpy as np
+
+size = 2
+rank = 0
+
+x1 = pt.make_placeholder("x1", shape=(10, 4), dtype=np.float64)
+x2 = pt.make_placeholder("x2", shape=(10, 4), dtype=np.float64)
+x3 = pt.make_placeholder("x3", shape=(10, 4), dtype=np.float64)
+x4 = pt.make_placeholder("x4", shape=(10, 4), dtype=np.float64)
+
+
+tmp1 = (x1 + x2).tagged(pt.tags.ImplStored())
+tmp2 = tmp1 + x3
+# "marking" *tmp2* so that its duplication can be clearly visualized.
+tmp2 = tmp2.tagged(pt.tags.Named("tmp2"))
+tmp3 = (2 * x4).tagged(pt.tags.ImplStored())
+tmp4 = tmp2 + tmp3
+
+recv = pt.staple_distributed_send(tmp4, dest_rank=(rank-1) % size, comm_tag=10,
+        stapled_to=pt.make_distributed_recv(
+            src_rank=(rank+1) % size, comm_tag=10, shape=(10, 4), dtype=int))
+
+out = tmp2 + recv
+result = pt.make_dict_of_named_arrays({"out": out})
+
+partitions = pt.find_distributed_partition(result)
+
+# Visualize *partitions* to see that each of the two partitions contains a node
+# named 'tmp2'.
+pt.show_dot_graph(partitions)

--- a/pytato/__init__.py
+++ b/pytato/__init__.py
@@ -75,7 +75,8 @@ from pytato.distributed import (make_distributed_send, make_distributed_recv,
                                 staple_distributed_send,
                                 find_distributed_partition,
                                 number_distributed_tags,
-                                execute_distributed_partition)
+                                execute_distributed_partition,
+                                )
 
 from pytato.partition import generate_code_for_partition
 

--- a/pytato/analysis/__init__.py
+++ b/pytato/analysis/__init__.py
@@ -25,12 +25,17 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
-from typing import Mapping, Dict, Union, Set, Tuple, Any
+from typing import (Mapping, Dict, Union, Set, Tuple, Any, FrozenSet,
+                    TYPE_CHECKING)
 from pytato.array import (Array, IndexLambda, Stack, Concatenate, Einsum,
                           DictOfNamedArrays, NamedArray,
-                          IndexBase, IndexRemappingBase, InputArgumentBase)
+                          IndexBase, IndexRemappingBase, InputArgumentBase,
+                          ShapeType)
 from pytato.transform import Mapper, ArrayOrNames, CachedWalkMapper
 from pytato.loopy import LoopyCall
+
+if TYPE_CHECKING:
+    from pytato.distributed import DistributedRecv, DistributedSendRefHolder
 
 __doc__ = """
 .. currentmodule:: pytato.analysis
@@ -40,6 +45,8 @@ __doc__ = """
 .. autofunction:: is_einsum_similar_to_subscript
 
 .. autofunction:: get_num_nodes
+
+.. autoclass:: DirectPredecessorsGetter
 """
 
 
@@ -265,6 +272,83 @@ def is_einsum_similar_to_subscript(expr: Einsum, subscripts: str) -> bool:
         # }}}
 
     return True
+
+
+# {{{ DirectPredecessorsGetter
+
+class DirectPredecessorsGetter(Mapper):
+    """
+    Mapper to get the
+    `direct predecessors
+    <https://en.wikipedia.org/wiki/Glossary_of_graph_theory#direct_predecessor>`__
+    of a node.
+
+    .. note::
+
+        We only consider the predecessors of a nodes in a data-flow sense.
+    """
+    def _get_preds_from_shape(self, shape: ShapeType) -> FrozenSet[Array]:
+        return frozenset({dim for dim in shape if isinstance(dim, Array)})
+
+    def map_index_lambda(self, expr: IndexLambda) -> FrozenSet[Array]:
+        return (frozenset(expr.bindings.values())
+                | self._get_preds_from_shape(expr.shape))
+
+    def map_stack(self, expr: Stack) -> FrozenSet[Array]:
+        return (frozenset(expr.arrays)
+                | self._get_preds_from_shape(expr.shape))
+
+    def map_concatenate(self, expr: Concatenate) -> FrozenSet[Array]:
+        return (frozenset(expr.arrays)
+                | self._get_preds_from_shape(expr.shape))
+
+    def map_einsum(self, expr: Einsum) -> FrozenSet[Array]:
+        return (frozenset(expr.args)
+                | self._get_preds_from_shape(expr.shape))
+
+    def map_loopy_call_result(self, expr: NamedArray) -> FrozenSet[Array]:
+        from pytato.loopy import LoopyCallResult, LoopyCall
+        assert isinstance(expr, LoopyCallResult)
+        assert isinstance(expr._container, LoopyCall)
+        return (frozenset(ary
+                          for ary in expr._container.bindings.values()
+                          if isinstance(ary, Array))
+                | self._get_preds_from_shape(expr.shape))
+
+    def _map_index_base(self, expr: IndexBase) -> FrozenSet[Array]:
+        return (frozenset([expr.array])
+                | frozenset(idx for idx in expr.indices
+                            if isinstance(idx, Array))
+                | self._get_preds_from_shape(expr.shape))
+
+    map_basic_index = _map_index_base
+    map_contiguous_advanced_index = _map_index_base
+    map_non_contiguous_advanced_index = _map_index_base
+
+    def _map_index_remapping_base(self, expr: IndexRemappingBase
+                                  ) -> FrozenSet[Array]:
+        return frozenset([expr.array])
+
+    map_roll = _map_index_remapping_base
+    map_axis_permutation = _map_index_remapping_base
+    map_reshape = _map_index_remapping_base
+
+    def _map_input_base(self, expr: InputArgumentBase) -> FrozenSet[Array]:
+        return self._get_preds_from_shape(expr.shape)
+
+    map_placeholder = _map_input_base
+    map_data_wrapper = _map_input_base
+    map_size_param = _map_input_base
+
+    def map_distributed_recv(self, expr: DistributedRecv) -> FrozenSet[Array]:
+        return self._get_preds_from_shape(expr.shape)
+
+    def map_distributed_send_ref_holder(self,
+                                        expr: DistributedSendRefHolder
+                                        ) -> FrozenSet[Array]:
+        return frozenset([expr.passthrough_data])
+
+# }}}
 
 
 # {{{ NodeCountMapper

--- a/pytato/distributed.py
+++ b/pytato/distributed.py
@@ -25,19 +25,28 @@ THE SOFTWARE.
 """
 
 from typing import (Any, Dict, Hashable, Tuple, Optional, Set,  # noqa: F401
-    List, FrozenSet, Callable, cast, Mapping)  # Mapping required by sphinx
+                    List, FrozenSet, Callable, cast, Mapping, Iterable
+                    )  # Mapping required by sphinx
+from pyrsistent.typing import PMap as PMapT
 
 from dataclasses import dataclass
 
 from pytools import UniqueNameGenerator
-from pytools.tag import Taggable, TagsType
+from pytools.tag import Taggable, TagsType, UniqueTag
 from pytato.array import (Array, _SuppliedShapeAndDtypeMixin,
-                          DictOfNamedArrays, ShapeType,
-                          Placeholder, make_placeholder,
-                          _get_default_axes, AxesT)
-from pytato.transform import ArrayOrNames, CopyMapper
+                          DictOfNamedArrays, ShapeType, Placeholder,
+                          make_placeholder, _get_default_axes, AxesT,
+                          NamedArray)
+from pytato.transform import (ArrayOrNames, CopyMapper, Mapper,
+                              CachedWalkMapper, CopyMapperWithExtraArgs,
+                              CombineMapper)
+
 from pytato.partition import GraphPart, GraphPartition, PartId, GraphPartitioner
 from pytato.target import BoundProgram
+from pytato.analysis import DirectPredecessorsGetter
+from pyrsistent import pmap
+from functools import cached_property
+from pytato.scalar_expr import SCALAR_CLASSES
 
 import numpy as np
 
@@ -207,6 +216,20 @@ class DistributedSendRefHolder(Array):
     @property
     def dtype(self) -> np.dtype[Any]:
         return self.passthrough_data.dtype
+
+    def copy(self, **kwargs: Any) -> DistributedSendRefHolder:
+        # override 'Array.copy' because
+        # 'DistributedSendRefHolder.axes' is a read-only field.
+        send = kwargs.pop("send", self.send)
+        passthrough_data = kwargs.pop("passthrough_data", self.passthrough_data)
+        tags = kwargs.pop("tags", self.tags)
+
+        if kwargs:
+            raise ValueError("Cannot assign"
+                             f" DistributedSendRefHolder.'{set(kwargs)}'")
+        return DistributedSendRefHolder(send,
+                                        passthrough_data,
+                                        tags)
 
 
 class DistributedRecv(_SuppliedShapeAndDtypeMixin, Array):
@@ -411,13 +434,7 @@ def _gather_distributed_comm_info(partition: GraphPartition,
 # }}}
 
 
-# {{{ find distributed partition
-
-@dataclass(frozen=True, eq=True)
-class DistributedPartitionId():
-    fed_sends: object
-    feeding_recvs: object
-
+# {{{ find_distributed_partition
 
 class _DistributedGraphPartitioner(GraphPartitioner):
 
@@ -446,64 +463,473 @@ class _DistributedGraphPartitioner(GraphPartitioner):
         return _gather_distributed_comm_info(partition, self.pid_to_dist_sends)
 
 
-def find_distributed_partition(
-        outputs: DictOfNamedArrays) -> DistributedGraphPartition:
-    """Finds a partitioning in a distributed context."""
+class _MandatoryPartitionOutputsCollector(CombineMapper[FrozenSet[Array]]):
+    """
+    Collects all nodes that, after partitioning, are necessarily outputs
+    of the partition to which they belong.
+    """
+    def __init__(self) -> None:
+        super().__init__()
+        self.partition_outputs: Set[Array] = set()
 
-    from pytato.transform import (UsersCollector, TopoSortMapper,
-                                  reverse_graph, tag_user_nodes)
+    def combine(self, *args: FrozenSet[Array]) -> FrozenSet[Array]:
+        from functools import reduce
+        return reduce(frozenset.union, args, frozenset())
 
-    gdm = UsersCollector()
-    gdm(outputs)
+    def map_distributed_send_ref_holder(self,
+                                        expr: DistributedSendRefHolder
+                                        ) -> FrozenSet[Array]:
+        return self.combine(frozenset([expr.send.data]),
+                            super().map_distributed_send_ref_holder(expr))
 
-    graph = gdm.node_to_users
+    def _map_input_base(self, expr: Array) -> FrozenSet[Array]:
+        return frozenset()
 
-    # type-ignore-reason:
-    # 'graph' also includes DistributedSend nodes, which are not Arrays
-    rev_graph = reverse_graph(graph)  # type: ignore[arg-type]
+    map_placeholder = _map_input_base
+    map_data_wrapper = _map_input_base
+    map_size_param = _map_input_base
+    map_distributed_recv = _map_input_base
 
-    # FIXME: Inefficient... too many traversals
-    node_to_feeding_recvs: Dict[ArrayOrNames, Set[ArrayOrNames]] = {}
-    for node in graph:
-        node_to_feeding_recvs.setdefault(node, set())
-        if isinstance(node, DistributedRecv):
-            tag_user_nodes(graph, tag=node,  # type: ignore[arg-type]
-                            starting_point=node,
-                            node_to_tags=node_to_feeding_recvs)
 
-    node_to_fed_sends: Dict[ArrayOrNames, Set[ArrayOrNames]] = {}
-    for node in rev_graph:
-        node_to_fed_sends.setdefault(node, set())
-        if isinstance(node, DistributedSend):
-            tag_user_nodes(rev_graph, tag=node, starting_point=node,
-                            node_to_tags=node_to_fed_sends)
+class _MaterializedArrayCollector(CachedWalkMapper):
+    """
+    Collects all nodes that have to be materialized during code-generation.
+    """
+    def __init__(self) -> None:
+        super().__init__()
+        self.materialized_arrays: Set[Array] = set()
 
-    def get_part_id(expr: ArrayOrNames) -> DistributedPartitionId:
-        return DistributedPartitionId(frozenset(node_to_fed_sends[expr]),
-                                      frozenset(node_to_feeding_recvs[expr]))
+    def post_visit(self, expr: Any) -> None:
+        from pytato.tags import ImplStored
+        from pytato.loopy import LoopyCallResult
 
-    # {{{ Sanity checks
+        if (isinstance(expr, Array) and expr.tags_of_type(ImplStored)):
+            self.materialized_arrays.add(expr)
 
-    if __debug__:
-        for node, _ in node_to_feeding_recvs.items():
-            for n in node_to_feeding_recvs[node]:
-                assert(isinstance(n, DistributedRecv))
+        if isinstance(expr, LoopyCallResult):
+            self.materialized_arrays.add(expr)
+            from pytato.loopy import LoopyCall
+            assert isinstance(expr._container, LoopyCall)
+            for _, subexpr in sorted(expr._container.bindings.items()):
+                if isinstance(subexpr, Array):
+                    self.materialized_arrays.add(subexpr)
+                else:
+                    assert isinstance(subexpr, SCALAR_CLASSES)
 
-        for node, _ in node_to_fed_sends.items():
-            for n in node_to_fed_sends[node]:
-                assert(isinstance(n, DistributedSend))
+        if isinstance(expr, DictOfNamedArrays):
+            for _, subexpr in sorted(expr._data.items()):
+                assert isinstance(subexpr, Array)
+                self.materialized_arrays.add(subexpr)
 
-        tm = TopoSortMapper()
-        tm(outputs)
 
-        for node in tm.topological_order:
-            get_part_id(node)
+class _DominantMaterializedPredecessorsCollector(Mapper):
+    """
+    A Mapper whose mapper method for a node returns the materialized predecessors
+    just after the point the node is evaluated.
+    """
+    def __init__(self, materialized_arrays: FrozenSet[Array]) -> None:
+        super().__init__()
+        self.materialized_arrays = materialized_arrays
+        self.cache: Dict[ArrayOrNames, FrozenSet[Array]] = {}
+
+    def _combine(self, values: Iterable[Array]) -> FrozenSet[Array]:
+        from functools import reduce
+        return reduce(frozenset.union,
+                      (self.rec(v) for v in values),
+                      frozenset())
+
+    # type-ignore reason: return type not compatible with Mapper.rec's type
+    def rec(self, expr: ArrayOrNames) -> FrozenSet[Array]:  # type: ignore[override]
+        try:
+            return self.cache[expr]
+        except KeyError:
+            # type-ignore reason: type not compatible with super.rec() type
+            result: FrozenSet[Array] = super().rec(expr)  # type: ignore[type-var]
+            self.cache[expr] = result
+            return result
+
+    @cached_property
+    def direct_preds_getter(self) -> DirectPredecessorsGetter:
+        return DirectPredecessorsGetter()
+
+    def _map_generic_node(self, expr: Array) -> FrozenSet[Array]:
+        direct_preds = self.direct_preds_getter(expr)
+
+        if expr in self.materialized_arrays:
+            return frozenset([expr])
+        else:
+            return self._combine(direct_preds)
+
+    map_placeholder = _map_generic_node
+    map_data_wrapper = _map_generic_node
+    map_size_param = _map_generic_node
+
+    map_index_lambda = _map_generic_node
+    map_stack = _map_generic_node
+    map_concatenate = _map_generic_node
+    map_roll = _map_generic_node
+    map_axis_permutation = _map_generic_node
+    map_basic_index = _map_generic_node
+    map_contiguous_advanced_index = _map_generic_node
+    map_non_contiguous_advanced_index = _map_generic_node
+    map_reshape = _map_generic_node
+    map_einsum = _map_generic_node
+    map_distributed_recv = _map_generic_node
+
+    def map_named_array(self, expr: NamedArray) -> FrozenSet[Array]:
+        raise NotImplementedError("only LoopyCallResult named array"
+                                  " supported for now.")
+
+    def map_dict_of_named_arrays(self, expr: DictOfNamedArrays
+                                 ) -> FrozenSet[Array]:
+        raise NotImplementedError("Dict of named arrays not (yet) implemented")
+
+    def map_loopy_call_result(self, expr: NamedArray) -> FrozenSet[Array]:
+        # ``loopy call result` is always materialized. However, make sure to
+        # traverse its arguments.
+        assert expr in self.materialized_arrays
+        return self._map_generic_node(expr)
+
+    def map_distributed_send_ref_holder(self,
+                                        expr: DistributedSendRefHolder
+                                        ) -> FrozenSet[Array]:
+        return self.rec(expr.passthrough_data)
+
+
+class _DominantMaterializedPredecessorsRecorder(CachedWalkMapper):
+    """
+    For each node in an expression graph, this mapper records the dominant
+    predecessors of each node of an expression graph into
+    :attr:`array_to_mat_preds`.
+    """
+    def __init__(self, mat_preds_getter: Callable[[Array], FrozenSet[Array]]
+                 ) -> None:
+        super().__init__()
+        self.mat_preds_getter = mat_preds_getter
+        self.array_to_mat_preds: Dict[Array, FrozenSet[Array]] = {}
+
+    @cached_property
+    def direct_preds_getter(self) -> DirectPredecessorsGetter:
+        return DirectPredecessorsGetter()
+
+    def post_visit(self, expr: Any) -> None:
+        from functools import reduce
+        if isinstance(expr, Array):
+            self.array_to_mat_preds[expr] = reduce(
+                frozenset.union,
+                (self.mat_preds_getter(pred)
+                 for pred in self.direct_preds_getter(expr)),
+                frozenset())
+
+
+def _linearly_schedule_batches(
+        predecessors: PMapT[Array, FrozenSet[Array]]) -> PMapT[Array, int]:
+    """
+    Used by :func:`find_distributed_partition`. Based on the dependencies in
+    *predecessors*, each node is assigned a time such that evaluating the array
+    at that point in time would not violate dependencies. This "time" or "batch
+    number" is then used as a partition ID.
+    """
+    from functools import reduce
+    current_time = 0
+    ary_to_time = {}
+    scheduled_nodes: Set[Array] = set()
+    all_nodes = frozenset(predecessors)
+
+    # assert that the keys contain all the nodes
+    assert reduce(frozenset.union,
+                  predecessors.values(),
+                  cast(FrozenSet[Array], frozenset())) <= frozenset(predecessors)
+
+    while len(scheduled_nodes) < len(all_nodes):
+        # {{{ eagerly schedule nodes whose predecessors have been scheduled
+
+        nodes_to_schedule = {node
+                             for node, preds in predecessors.items()
+                             if ((node not in scheduled_nodes)
+                                 and (preds <= scheduled_nodes))}
+        for node in nodes_to_schedule:
+            assert node not in ary_to_time
+            ary_to_time[node] = current_time
+
+        scheduled_nodes.update(nodes_to_schedule)
+
+        current_time += 1
+
+        # }}}
+
+    return pmap(ary_to_time)
+
+
+def _assign_materialized_arrays_to_part_id(
+        materialized_arrays: FrozenSet[Array],
+        array_to_output_deps: Mapping[Array, FrozenSet[Array]],
+        outputs_to_part_id: Mapping[Array, int]
+) -> PMapT[Array, int]:
+    """
+    Returns a mapping from a materialized array to the part's ID where all the
+    inputs of the array expression are available.
+
+    Invoked as an intermediate step in :func:`find_distributed_partition`.
+
+    .. note::
+
+        In this heuristic we compute the materialized array as soon as its
+        inputs are available. In some cases it might be worth exploring
+        schedules where the evaluation of an array is delayed until one of
+        its users demand it.
+    """
+
+    materialized_array_to_part_id: Dict[Array, int] = {}
+
+    for ary in materialized_arrays:
+        materialized_array_to_part_id[ary] = max(
+            (outputs_to_part_id[dep]
+             for dep in array_to_output_deps[ary]),
+            default=-1) + 1
+
+    return pmap(materialized_array_to_part_id)
+
+
+def _get_array_to_dominant_materialized_deps(
+        outputs: DictOfNamedArrays,
+        materialized_arrays: FrozenSet[Array]) -> PMapT[Array, FrozenSet[Array]]:
+    """
+    Returns a mapping from each node in the DAG *outputs* to a :class:`frozenset`
+    of its dominant materialized predecessors.
+    """
+
+    dominant_materialized_deps = _DominantMaterializedPredecessorsCollector(
+        materialized_arrays)
+    dominant_materialized_deps_recorder = (
+        _DominantMaterializedPredecessorsRecorder(dominant_materialized_deps))
+    dominant_materialized_deps_recorder(outputs)
+    return pmap(dominant_materialized_deps_recorder.array_to_mat_preds)
+
+
+def _get_materialized_arrays_promoted_to_partition_outputs(
+        ary_to_dominant_stored_preds: Mapping[Array, FrozenSet[Array]],
+        stored_ary_to_part_id: Mapping[Array, int],
+        materialized_arrays: FrozenSet[Array]
+) -> FrozenSet[Array]:
+    """
+    Returns a :class:`frozenset` of materialized arrays that are used by
+    multiple partitions. Materialized arrays that are used by multiple
+    partitions are special in that they *must* be promoted as the outputs of a
+    partition.
+
+    Invoked as an intermediate step in :func:`find_distributed_partition`.
+
+    :arg ary_to_dominant_stored_preds: A mapping from array to the dominant
+        stored predecessors. A stored array can be either a mandatory partition
+        output or a materialized array as indicated by the user.
+    """
+    materialized_ary_to_part_id_users: Dict[Array, Set[int]] = {}
+
+    for ary in stored_ary_to_part_id:
+        stored_preds = ary_to_dominant_stored_preds[ary]
+        for pred in stored_preds:
+            if pred in materialized_arrays:
+                (materialized_ary_to_part_id_users
+                 .setdefault(pred, set())
+                 .add(stored_ary_to_part_id[ary]))
+
+    return frozenset({ary
+                      for ary, users in materialized_ary_to_part_id_users.items()
+                      if users != {stored_ary_to_part_id[ary]}})
+
+
+@dataclass(frozen=True, eq=True, repr=True)
+class PartIDTag(UniqueTag):
+    """
+    A tag applicable to a :class:`pytato.Array` recording to which part the
+    array belongs.
+    """
+    part_id: int
+
+
+class _PartIDTagAssigner(CopyMapperWithExtraArgs):
+    """
+    Used by :func:`find_distributed_partition` to assign each array
+    node a :class:`PartIDTag`.
+    """
+    def __init__(self,
+                 stored_array_to_part_id: Mapping[Array, int],
+                 partition_outputs: FrozenSet[Array]) -> None:
+        self.stored_array_to_part_id = stored_array_to_part_id
+        self.partition_outputs = partition_outputs
+
+        # type-ignore reason: incompatible  attribute type wrt base.
+        self._cache: Dict[Tuple[ArrayOrNames, int],
+                          Any] = {}  # type: ignore[assignment]
+
+    # type-ignore-reason: incompatible with super class
+    def cache_key(self,  # type: ignore[override]
+                  expr: ArrayOrNames,
+                  user_part_id: int
+                  ) -> Tuple[ArrayOrNames, int]:
+
+        return (expr, user_part_id)
+
+    # type-ignore-reason: incompatible with super class
+    def rec(self,  # type: ignore[override]
+            expr: ArrayOrNames,
+            user_part_id: int) -> Any:
+        key = self.cache_key(expr, user_part_id)
+        try:
+            return self._cache[key]
+        except KeyError:
+            if isinstance(expr, Array):
+                if expr in self.stored_array_to_part_id:
+                    assert ((self.stored_array_to_part_id[expr]
+                             == user_part_id)
+                            or expr in self.partition_outputs)
+                    # at stored array the part id changes
+                    user_part_id = self.stored_array_to_part_id[expr]
+
+                expr = expr.tagged(PartIDTag(user_part_id))
+
+            result = super().rec(expr, user_part_id)
+            self._cache[key] = result
+            return result
+
+
+def find_distributed_partition(outputs: DictOfNamedArrays
+                               ) -> DistributedGraphPartition:
+    """
+    Partitions *outputs* into parts. Between two parts communication
+    statements (sends/receives) are scheduled.
+
+    .. note::
+
+        The partitioning of a DAG generally does not have a unique solution.
+        The heuristic employed by this partitioner is as follows:
+
+        1. The data contained in :class:`~pytato.DistributedSend` are marked as
+           *mandatory part outputs*.
+        2. Based on the dependencies in *outputs*, a DAG is constructed with
+           only the mandatory part outputs as the nodes.
+        3. Using a topological sort the mandatory part outputs are assigned a
+           "time" (an integer) such that evaluating these outputs at that time
+           would preserve dependencies. We maximize the number of part outputs
+           scheduled at a each "time". This requirement ensures our topological
+           sort is deterministic.
+        4. We then turn our attention to the other arrays that are allocated to a
+           buffer. These are the materialized arrays and belong to one of the
+           following classes:
+           - An :class:`~pytato.Array` tagged with :class:`pytato.tags.ImplStored`.
+           - The expressions in a :class:`~pytato.DictOfNamedArrays`.
+        5. Based on *outputs*, we compute the predecessors of a materialized
+           that were a part of the mandatory part outputs. A materialized array
+           is scheduled to be evaluated in a part as soon as all of its inputs
+           are available. Note that certain inputs (like
+           :class:`~pytato.DistributedRecv`) might not be available until
+           certain mandatory part outputs have been evaluated.
+        6. From *outputs*, we can construct a DAG comprising only of mandatory
+           part outputs and materialized arrays. We mark all materialized
+           arrays that are being used by nodes in a part that's not the one in
+           which the materialized array itself was evaluated. Such materialized
+           arrays are also realized as part outputs. This is done to avoid
+           recomputations.
+
+        Knobs to tweak the partition:
+
+        1. By removing dependencies between the mandatory part outputs, the
+           resulting DAG would lead to fewer number of parts and parts with
+           more number of nodes in them. Similarly, adding dependencies between
+           the part outputs would lead to smaller parts.
+        2. Tagging nodes with :class:~pytato.tags.ImplStored` would help in
+           avoiding re-computations.
+    """
+    from pytato.transform import SubsetDependencyMapper
+    from pytato.array import make_dict_of_named_arrays
+    from pytato.partition import find_partition
+
+    # {{{ get partitioning helper data corresponding to the DAG
+
+    partition_outputs = _MandatoryPartitionOutputsCollector()(outputs)
+
+    # materialized_arrays: "extra" arrays that must be stored in a buffer
+    materialized_arrays_collector = _MaterializedArrayCollector()
+    materialized_arrays_collector(outputs)
+    materialized_arrays = frozenset(
+        materialized_arrays_collector.materialized_arrays) - partition_outputs
 
     # }}}
 
-    from pytato.partition import find_partition
+    dep_mapper = SubsetDependencyMapper(partition_outputs)
+
+    # {{{ compute a dependency graph between outputs, schedule and partition
+
+    output_to_deps = pmap({partition_out: (dep_mapper(partition_out)
+                                           - frozenset([partition_out]))
+                           for partition_out in partition_outputs})
+
+    output_to_part_id = _linearly_schedule_batches(output_to_deps)
+
+    # }}}
+
+    # {{{ assign each materialized array a partition ID in which it will be placed
+
+    materialized_array_to_output_deps = pmap({ary: (dep_mapper(ary)
+                                                    - frozenset([ary]))
+                                              for ary in materialized_arrays})
+    materialized_ary_to_part_id = _assign_materialized_arrays_to_part_id(
+        materialized_arrays,
+        materialized_array_to_output_deps,
+        output_to_part_id)
+
+    assert frozenset(materialized_ary_to_part_id) == materialized_arrays
+
+    # }}}
+
+    stored_ary_to_part_id = materialized_ary_to_part_id.update(output_to_part_id)
+
+    # {{{ find which materialized arrays have users in multiple parts
+    # (and promote them to part outputs)
+
+    ary_to_dominant_materialized_deps = (
+        _get_array_to_dominant_materialized_deps(outputs,
+                                                      (materialized_arrays
+                                                       | partition_outputs)))
+
+    materialized_arrays_realized_as_partition_outputs = (
+        _get_materialized_arrays_promoted_to_partition_outputs(
+            ary_to_dominant_materialized_deps,
+            stored_ary_to_part_id,
+            materialized_arrays))
+
+    # }}}
+
+    # {{{ tag each node with its part ID
+
+    # Why is this necessary? (I.e. isn't the mapping *stored_ary_to_part_id* enough?)
+    # By assigning tags we also duplicate the non-materialized nodes that are
+    # to be made available in multiple parts. Parts being disjoint is one of
+    # the requirements of *find_partition*.
+    part_id_tag_assigner = _PartIDTagAssigner(
+        stored_ary_to_part_id,
+        partition_outputs | materialized_arrays_realized_as_partition_outputs)
+
+    partitioned_outputs = make_dict_of_named_arrays({
+        name: part_id_tag_assigner(subexpr, stored_ary_to_part_id[subexpr])
+        for name, subexpr in outputs._data.items()})
+
+    # }}}
+
+    def get_part_id(expr: ArrayOrNames) -> int:
+        if not isinstance(expr, Array):
+            raise NotImplementedError("find_distributed_partition"
+                                      " cannot partition DictOfNamedArrays")
+        assert isinstance(expr, Array)
+        tag, = expr.tags_of_type(PartIDTag)
+        return tag.part_id
+
     return cast(DistributedGraphPartition,
-            find_partition(outputs, get_part_id, _DistributedGraphPartitioner))
+                find_partition(partitioned_outputs,
+                               get_part_id,
+                               _DistributedGraphPartitioner)
+                )
 
 # }}}
 

--- a/pytato/transform.py
+++ b/pytato/transform.py
@@ -63,6 +63,7 @@ __doc__ = """
 .. autoclass:: Mapper
 .. autoclass:: CachedMapper
 .. autoclass:: CopyMapper
+.. autoclass:: CopyMapperWithExtraArgs
 .. autoclass:: CombineMapper
 .. autoclass:: DependencyMapper
 .. autoclass:: InputGatherer
@@ -332,13 +333,203 @@ class CopyMapper(CachedMapper[ArrayOrNames]):
                     data=self.rec(expr.send.data),
                     dest_rank=expr.send.dest_rank,
                     comm_tag=expr.send.comm_tag),
-                self.rec(expr.passthrough_data))
+                self.rec(expr.passthrough_data),
+                tags=expr.tags)
 
     def map_distributed_recv(self, expr: DistributedRecv) -> Array:
         from pytato.distributed import DistributedRecv
         return DistributedRecv(
                src_rank=expr.src_rank, comm_tag=expr.comm_tag,
                shape=self.rec_idx_or_size_tuple(expr.shape),
+               dtype=expr.dtype, tags=expr.tags)
+
+
+class CopyMapperWithExtraArgs(CachedMapper[ArrayOrNames]):
+    """
+    Similar to :class:`CopyMapper`, but each mapper method takes extra
+    ``*args``, ``**kwargs`` that are propagated along a path by default.
+
+    The logic in :class:`CopyMapper` purposefully does not take the extra
+    arguments to keep the cost of its each call frame low.
+    """
+    def __init__(self) -> None:
+        # type-ignored as '._cache' attribute is not coherent with the base
+        # class
+        self._cache: Dict[Tuple[ArrayOrNames,
+                                Tuple[Any, ...],
+                                Tuple[Tuple[str, Any], ...]
+                                ],
+                          Any] = {}  # type: ignore[assignment]
+
+    def cache_key(self,
+                  expr: ArrayOrNames,
+                  *args: Any, **kwargs: Any) -> Tuple[ArrayOrNames,
+                                                      Tuple[Any, ...],
+                                                      Tuple[Tuple[str, Any], ...]
+                                                      ]:
+        return (expr, args, tuple(sorted(kwargs.items())))
+
+    def rec(self,
+            expr: ArrayOrNames,
+            *args: Any, **kwargs: Any) -> Any:
+        key = self.cache_key(expr, *args, **kwargs)
+        try:
+            return self._cache[key]
+        except KeyError:
+            result = Mapper.rec(self, expr,
+                                *args,
+                                **kwargs)  # type: ignore[type-var]
+            self._cache[key] = result
+            return result
+
+    def rec_idx_or_size_tuple(self, situp: Tuple[IndexOrShapeExpr, ...],
+                              *args: Any, **kwargs: Any
+                              ) -> Tuple[IndexOrShapeExpr, ...]:
+        return tuple(self.rec(s, *args, **kwargs) if isinstance(s, Array) else s
+                     for s in situp)
+
+    def map_index_lambda(self, expr: IndexLambda,
+                         *args: Any, **kwargs: Any) -> Array:
+        bindings: Dict[str, Array] = {
+                name: self.rec(subexpr, *args, **kwargs)
+                for name, subexpr in sorted(expr.bindings.items())}
+        return IndexLambda(expr=expr.expr,
+                           shape=self.rec_idx_or_size_tuple(expr.shape,
+                                                            *args, **kwargs),
+                           dtype=expr.dtype,
+                           bindings=bindings,
+                           axes=expr.axes,
+                           tags=expr.tags)
+
+    def map_placeholder(self, expr: Placeholder, *args: Any, **kwargs: Any) -> Array:
+        assert expr.name is not None
+        return Placeholder(name=expr.name,
+                           shape=self.rec_idx_or_size_tuple(expr.shape,
+                                                            *args, **kwargs),
+                           dtype=expr.dtype,
+                           axes=expr.axes,
+                           tags=expr.tags)
+
+    def map_stack(self, expr: Stack, *args: Any, **kwargs: Any) -> Array:
+        arrays = tuple(self.rec(arr, *args, **kwargs) for arr in expr.arrays)
+        return Stack(arrays=arrays, axis=expr.axis, axes=expr.axes, tags=expr.tags)
+
+    def map_concatenate(self, expr: Concatenate, *args: Any, **kwargs: Any) -> Array:
+        arrays = tuple(self.rec(arr, *args, **kwargs) for arr in expr.arrays)
+        return Concatenate(arrays=arrays, axis=expr.axis,
+                           axes=expr.axes, tags=expr.tags)
+
+    def map_roll(self, expr: Roll, *args: Any, **kwargs: Any) -> Array:
+        return Roll(array=self.rec(expr.array, *args, **kwargs),
+                    shift=expr.shift,
+                    axis=expr.axis,
+                    axes=expr.axes,
+                    tags=expr.tags)
+
+    def map_axis_permutation(self, expr: AxisPermutation,
+                             *args: Any, **kwargs: Any) -> Array:
+        return AxisPermutation(array=self.rec(expr.array, *args, **kwargs),
+                               axis_permutation=expr.axis_permutation,
+                               axes=expr.axes,
+                               tags=expr.tags)
+
+    def _map_index_base(self, expr: IndexBase, *args: Any, **kwargs: Any) -> Array:
+        return type(expr)(self.rec(expr.array, *args, **kwargs),
+                          indices=self.rec_idx_or_size_tuple(expr.indices,
+                                                             *args, **kwargs),
+                          axes=expr.axes,
+                          tags=expr.tags)
+
+    def map_basic_index(self, expr: BasicIndex, *args: Any, **kwargs: Any) -> Array:
+        return self._map_index_base(expr, *args, **kwargs)
+
+    def map_contiguous_advanced_index(self,
+                                      expr: AdvancedIndexInContiguousAxes,
+                                      *args: Any, **kwargs: Any
+
+                                      ) -> Array:
+        return self._map_index_base(expr, *args, **kwargs)
+
+    def map_non_contiguous_advanced_index(self,
+                                          expr: AdvancedIndexInNoncontiguousAxes,
+                                          *args: Any, **kwargs: Any
+                                          ) -> Array:
+        return self._map_index_base(expr)
+
+    def map_data_wrapper(self, expr: DataWrapper,
+                         *args: Any, **kwargs: Any) -> Array:
+        return DataWrapper(name=expr.name,
+                data=expr.data,
+                shape=self.rec_idx_or_size_tuple(expr.shape, *args, **kwargs),
+                axes=expr.axes,
+                tags=expr.tags)
+
+    def map_size_param(self, expr: SizeParam, *args: Any, **kwargs: Any) -> Array:
+        assert expr.name is not None
+        return SizeParam(name=expr.name, axes=expr.axes, tags=expr.tags)
+
+    def map_einsum(self, expr: Einsum, *args: Any, **kwargs: Any) -> Array:
+        return Einsum(expr.access_descriptors,
+                      tuple(self.rec(arg, *args, **kwargs) for arg in expr.args),
+                      axes=expr.axes,
+                      tags=expr.tags)
+
+    def map_named_array(self, expr: NamedArray, *args: Any, **kwargs: Any) -> Array:
+        return type(expr)(self.rec(expr._container, *args, **kwargs),
+                          expr.name,
+                          axes=expr.axes,
+                          tags=expr.tags)
+
+    def map_dict_of_named_arrays(self,
+            expr: DictOfNamedArrays, *args: Any, **kwargs: Any) -> DictOfNamedArrays:
+        return DictOfNamedArrays({key: self.rec(val.expr, *args, **kwargs)
+                                  for key, val in expr.items()})
+
+    def map_loopy_call(self, expr: LoopyCall,
+                       *args: Any, **kwargs: Any) -> LoopyCall:
+        bindings = {name: (self.rec(subexpr, *args, **kwargs)
+                           if isinstance(subexpr, Array)
+                           else subexpr)
+                    for name, subexpr in sorted(expr.bindings.items())}
+
+        return LoopyCall(translation_unit=expr.translation_unit,
+                         bindings=bindings,
+                         entrypoint=expr.entrypoint)
+
+    def map_loopy_call_result(self, expr: LoopyCallResult,
+                              *args: Any, **kwargs: Any) -> Array:
+        return LoopyCallResult(
+                loopy_call=self.rec(expr._container, *args, **kwargs),
+                name=expr.name,
+                axes=expr.axes,
+                tags=expr.tags)
+
+    def map_reshape(self, expr: Reshape,
+                    *args: Any, **kwargs: Any) -> Array:
+        return Reshape(self.rec(expr.array, *args, **kwargs),
+                       newshape=self.rec_idx_or_size_tuple(expr.newshape,
+                                                           *args, **kwargs),
+                       order=expr.order,
+                       axes=expr.axes,
+                       tags=expr.tags)
+
+    def map_distributed_send_ref_holder(self, expr: DistributedSendRefHolder,
+                                        *args: Any, **kwargs: Any) -> Array:
+        from pytato.distributed import DistributedSend, DistributedSendRefHolder
+        return DistributedSendRefHolder(
+                DistributedSend(
+                    data=self.rec(expr.send.data, *args, **kwargs),
+                    dest_rank=expr.send.dest_rank,
+                    comm_tag=expr.send.comm_tag),
+                self.rec(expr.passthrough_data, *args, **kwargs),
+                tags=expr.tags)
+
+    def map_distributed_recv(self, expr: DistributedRecv,
+                             *args: Any, **kwargs: Any) -> Array:
+        from pytato.distributed import DistributedRecv
+        return DistributedRecv(
+               src_rank=expr.src_rank, comm_tag=expr.comm_tag,
+               shape=self.rec_idx_or_size_tuple(expr.shape, *args, **kwargs),
                dtype=expr.dtype, tags=expr.tags)
 
 # }}}

--- a/pytato/transform.py
+++ b/pytato/transform.py
@@ -44,6 +44,8 @@ from pytato.array import (
 from pytato.loopy import LoopyCall, LoopyCallResult
 from dataclasses import dataclass
 from pytato.tags import ImplStored
+from pyrsistent import pmap
+from pyrsistent.typing import PMap as PMapT
 
 if TYPE_CHECKING:
     from pytato.distributed import DistributedSendRefHolder, DistributedRecv
@@ -1255,15 +1257,16 @@ def get_users(expr: ArrayOrNames) -> Dict[ArrayOrNames,
 
 # {{{ operations on graphs in dict form
 
-def reverse_graph(graph: Dict[ArrayOrNames, Set[ArrayOrNames]]) \
-        -> Dict[ArrayOrNames, Set[ArrayOrNames]]:
-    """Reverses a graph.
+def reverse_graph(graph: Mapping[ArrayOrNames, FrozenSet[ArrayOrNames]]
+                  ) -> PMapT[ArrayOrNames, FrozenSet[ArrayOrNames]]:
+    """
+    Reverses a graph.
 
     :param graph: A :class:`dict` representation of a directed graph, mapping each
         node to other nodes to which it is connected by edges. A possible
         use case for this function is the graph in
         :attr:`UsersCollector.node_to_users`.
-    :returns: A :class:`dict` representing *graph* with edges reversed.
+    :returns: A :class:`pyrsistent.PMap` representing *graph* with edges reversed.
     """
     result: Dict[ArrayOrNames, Set[ArrayOrNames]] = {}
 
@@ -1274,7 +1277,7 @@ def reverse_graph(graph: Dict[ArrayOrNames, Set[ArrayOrNames]]) \
         for other_node_key in edges:
             result.setdefault(other_node_key, set()).add(node_key)
 
-    return result
+    return pmap({k: frozenset(v) for k, v in result.items()})
 
 
 def _recursively_get_all_users(

--- a/test/test_distributed.py
+++ b/test/test_distributed.py
@@ -166,10 +166,10 @@ def _do_test_distributed_execution_random_dag(ctx_factory):
                 additional_generators=[
                     (comm_fake_prob, gen_comm)
                     ])
-        x_comm = make_random_dag(rdagc_comm)
+        pt_dag = pt.DictOfNamedArrays({"result": make_random_dag(rdagc_comm)})
+        x_comm = pt.transform.materialize_with_mpms(pt_dag)
 
-        distributed_partition = find_distributed_partition(
-                pt.DictOfNamedArrays({"result": x_comm}))
+        distributed_partition = find_distributed_partition(x_comm)
 
         # Transform symbolic tags into numeric ones for MPI
         distributed_partition, _new_mpi_base_tag = number_distributed_tags(


### PR DESCRIPTION
- Only materialized nodes can be inputs/outputs to a partition
- Non-materialized nodes that are used in multiple partitions are duplicated to uphold the lazy behavior of the expressions
- Implementation includes a working `examples/distributed_partition_sends_asap.py` which demonstrates the output for the partitioner.

Draft because:
- [x] Cleanup
- [x] Add tests
- [x] Pass CI
- [x] Nomenclature incoherence: Users/Successors/Predecessors