### PR TITLE
Some dtype fixes

### DIFF
--- a/pytato/array.py
+++ b/pytato/array.py
@@ -1983,15 +1983,19 @@ def make_data_wrapper(data: DataInterface,
 # {{{ full
 
 def full(shape: ConvertibleToShape, fill_value: ScalarType,
-         dtype: Any, order: str = "C") -> Array:
+         dtype: Any = None, order: str = "C") -> Array:
     """
     Returns an array of shape *shape* with all entries equal to *fill_value*.
     """
     if order != "C":
         raise ValueError("Only C-ordered arrays supported for now.")
 
+    if dtype is None:
+        dtype = np.array(fill_value).dtype
+    else:
+        dtype = np.dtype(dtype)
+
     shape = normalize_shape(shape)
-    dtype = np.dtype(dtype)
     return IndexLambda(dtype.type(fill_value), shape, dtype, {},
                        tags=_get_default_tags(),
                        axes=_get_default_axes(len(shape)))
@@ -2299,10 +2303,17 @@ def maximum(x1: ArrayOrScalar, x2: ArrayOrScalar) -> ArrayOrScalar:
     Returns the elementwise maximum of *x1*, *x2*. *x1*, *x2* being
     array-like objects that could be broadcasted together. NaNs are propagated.
     """
-    # https://github.com/python/mypy/issues/3186
-    from pytato.cmath import isnan
-    return where(logical_or(isnan(x1), isnan(x2)), np.NaN,  # type: ignore
-                 where(greater(x1, x2), x1, x2))
+    from pytato.utils import get_common_dtype_of_ary_or_scalars
+    common_dtype = get_common_dtype_of_ary_or_scalars([x1, x2])
+
+    if (np.issubdtype(common_dtype, np.floating)
+            or np.issubdtype(common_dtype, np.complexfloating)):
+        from pytato.cmath import isnan
+        # https://github.com/python/mypy/issues/3186
+        return where(logical_or(isnan(x1), isnan(x2)), np.NaN,  # type: ignore
+                     where(greater(x1, x2), x1, x2))
+    else:
+        return where(greater(x1, x2), x1, x2)
 
 
 def minimum(x1: ArrayOrScalar, x2: ArrayOrScalar) -> ArrayOrScalar:
@@ -2310,10 +2321,17 @@ def minimum(x1: ArrayOrScalar, x2: ArrayOrScalar) -> ArrayOrScalar:
     Returns the elementwise minimum of *x1*, *x2*. *x1*, *x2* being
     array-like objects that could be broadcasted together. NaNs are propagated.
     """
-    # https://github.com/python/mypy/issues/3186
-    from pytato.cmath import isnan
-    return where(logical_or(isnan(x1), isnan(x2)), np.NaN,  # type: ignore
-                 where(less(x1, x2), x1, x2))
+    from pytato.utils import get_common_dtype_of_ary_or_scalars
+    common_dtype = get_common_dtype_of_ary_or_scalars([x1, x2])
+
+    if (np.issubdtype(common_dtype, np.floating)
+            or np.issubdtype(common_dtype, np.complexfloating)):
+        from pytato.cmath import isnan
+        # https://github.com/python/mypy/issues/3186
+        return where(logical_or(isnan(x1), isnan(x2)), np.NaN,  # type: ignore
+                     where(less(x1, x2), x1, x2))
+    else:
+        return where(less(x1, x2), x1, x2)
 
 # }}}
 

--- a/pytato/utils.py
+++ b/pytato/utils.py
@@ -32,7 +32,8 @@ from pytato.array import (Array, ShapeType, IndexLambda, SizeParam, ShapeCompone
                           DtypeOrScalar, ArrayOrScalar, BasicIndex,
                           AdvancedIndexInContiguousAxes,
                           AdvancedIndexInNoncontiguousAxes,
-                          ConvertibleToIndexExpr, IndexExpr, NormalizedSlice)
+                          ConvertibleToIndexExpr, IndexExpr, NormalizedSlice,
+                          _dtype_any)
 from pytato.scalar_expr import (ScalarExpression, IntegralScalarExpression,
                                 SCALAR_CLASSES, INT_CLASSES, BoolT)
 from pytools import UniqueNameGenerator
@@ -47,6 +48,7 @@ Helper routines
 .. autofunction:: are_shapes_equal
 .. autofunction:: get_shape_after_broadcasting
 .. autofunction:: dim_to_index_lambda_components
+.. autofunction:: get_common_dtype_of_ary_or_scalars
 """
 
 
@@ -565,3 +567,21 @@ def _index_into(ary: Array, indices: Tuple[ConvertibleToIndexExpr, ...]) -> Arra
                                    if isinstance(idx, NormalizedSlice)])))
 
 # }}}
+
+
+def get_common_dtype_of_ary_or_scalars(ary_or_scalars: Sequence[ArrayOrScalar]
+                                       ) -> _dtype_any:
+    array_types: List[_dtype_any] = []
+    scalar_types: List[_dtype_any] = []
+
+    for ary_or_scalar in ary_or_scalars:
+        if isinstance(ary_or_scalar, Array):
+            array_types.append(ary_or_scalar.dtype)
+        else:
+            assert isinstance(ary_or_scalar, SCALAR_CLASSES)
+            scalar_types.append(np.array(ary_or_scalar).dtype)
+
+    return np.find_common_type(array_types=array_types,
+                               scalar_types=scalar_types)
+
+# vim: fdm=marker


### PR DESCRIPTION
- maximum/minimum: should have NaN comparisons only for inexact dtypes
- full: Use the default `dtype=None`