### PR TITLE
CI: Force Open MPI for pytest

### DIFF
--- a/.test-conda-env-py3.yml
+++ b/.test-conda-env-py3.yml
@@ -12,3 +12,4 @@ dependencies:
 - islpy
 - sphinx-autodoc-typehints
 - mpi4py
+- openmpi  # Force using Open MPI since our pytest infrastructure needs it


### PR DESCRIPTION
Seems like recent changes in conda-forge prefer mpich over openmpi.

Should fix errors like https://github.com/inducer/pytato/runs/5791092495