### PR TITLE
Check identity in EqualityComparisonMapper

### DIFF
--- a/pytato/equality.py
+++ b/pytato/equality.py
@@ -82,7 +82,7 @@ class EqualityComparer:
                 else:
                     result = self.map_foreign(expr1, expr2)
             else:
-                result = method(expr1, expr2)
+                result = (expr1 is expr2) or method(expr1, expr2)
 
             self._cache[cache_key] = result
             return result


### PR DESCRIPTION
Not doing so would lead to a quadratic equality comparison cost in
if EqualityComparisonMapper is created and destroyed frequently, which
is typically the case in a CachedMapper.

Consider the graphs:

dag1 = 2 * x
dag2 = 2 * x  # note that 'dag1 is not dag2', but dag1 == dag2

where 'x' is a very large graph. Without this patch, comparing dag1 and
dag2 would redundantly traverse all elements of 'x'.

---
Experiment -- deduplicating data wrappers for graphs implemented in https://github.com/illinois-ceesd/drivers_y2-isolator would take ~7 minutes, but after this patch takes 3 seconds.