### PR TITLE
Implement pytato.expand_dims

### DIFF
--- a/pytato/__init__.py
+++ b/pytato/__init__.py
@@ -39,6 +39,7 @@ from pytato.array import (
         einsum,
 
         matmul, roll, transpose, stack, reshape, concatenate,
+        expand_dims,
 
         maximum, minimum, where,
 
@@ -95,7 +96,8 @@ __all__ = (
         "make_dict_of_named_arrays", "make_placeholder", "make_size_param",
         "make_data_wrapper", "einsum",
 
-        "matmul", "roll", "transpose", "stack", "reshape", "concatenate",
+        "matmul", "roll", "transpose", "stack", "reshape", "expand_dims",
+        "concatenate",
 
         "generate_loopy", "generate_jax",
 

--- a/pytato/array.py
+++ b/pytato/array.py
@@ -1348,11 +1348,11 @@ class Reshape(IndexRemappingBase):
     _mapper_method = "map_reshape"
 
     def __init__(self,
-            array: Array,
-            newshape: Tuple[int, ...],
-            order: str,
-            axes: AxesT,
-            tags: FrozenSet[Tag] = frozenset()):
+                 array: Array,
+                 newshape: ShapeType,
+                 order: str,
+                 axes: AxesT,
+                 tags: FrozenSet[Tag] = frozenset()):
         # FIXME: Get rid of this restriction
         assert order == "C"
 
@@ -1361,7 +1361,7 @@ class Reshape(IndexRemappingBase):
         self.order = order
 
     @property
-    def shape(self) -> Tuple[int, ...]:
+    def shape(self) -> ShapeType:
         return self.newshape
 
 # }}}

--- a/pytato/codegen.py
+++ b/pytato/codegen.py
@@ -380,7 +380,7 @@ class CodeGenPreprocessor(CopyMapper):
             assert expr.size == 1
             return ()
 
-        newstrides = [1]  # reshaped array strides
+        newstrides: List[IntegralT] = [1]  # reshaped array strides
         for new_axis_len in reversed(expr.shape[1:]):
             assert isinstance(new_axis_len, INT_CLASSES)
             newstrides.insert(0, newstrides[0]*new_axis_len)

--- a/pytato/tags.py
+++ b/pytato/tags.py
@@ -11,8 +11,9 @@ Pre-Defined Tags
 .. autoclass:: AssumeNonNegative
 """
 
-
+from typing import Tuple
 from pytools.tag import Tag, UniqueTag, tag_dataclass
+from dataclasses import dataclass
 
 
 # {{{ pre-defined tag: ImplementationStrategy
@@ -101,3 +102,25 @@ class AssumeNonNegative(Tag):
     :class:`~pytato.target.Target` that all entries of the tagged array are
     non-negative.
     """
+
+
+@dataclass(eq=True, frozen=True, repr=True)
+class ExpandedDimsReshape(UniqueTag):
+    """
+    A tag that can be attached to a :class:`~pytato.array.Reshape` to indicate
+    that the new dimensions created by :func:`pytato.expand_dims`.
+
+    :attr new_dims: A :class:`tuple` of the dimensions of the reshaped array
+        that were added.
+
+    .. testsetup::
+
+        >>> import pytato as pt
+
+    .. doctest::
+
+        >>> x = pt.make_placeholder("x", (10, 4), "float64")
+        >>> pt.expand_dims(x, (0, 2, 4)).tags_of_type(pt.tags.ExpandedDimsReshape)
+        frozenset({ExpandedDimsReshape(new_dims=(0, 2, 4))})
+    """
+    new_dims: Tuple[int, ...]

--- a/test/test_pytato.py
+++ b/test/test_pytato.py
@@ -884,6 +884,23 @@ def test_adv_indexing_into_zero_long_axes():
     # }}}
 
 
+def test_expand_dims_input_validate():
+    a = pt.make_placeholder("x", (10, 4), dtype="float64")
+
+    assert pt.expand_dims(a, (0, 2, 4)).shape == (1, 10, 1, 4, 1)
+    assert pt.expand_dims(a, (-5, -3, -1)).shape == (1, 10, 1, 4, 1)
+    assert pt.expand_dims(a, (-3)).shape == (1, 10, 4)
+
+    with pytest.raises(ValueError):
+        pt.expand_dims(a, (3, 3))
+
+    with pytest.raises(ValueError):
+        pt.expand_dims(a, (0, 2, 5))
+
+    with pytest.raises(ValueError):
+        pt.expand_dims(a, -4)
+
+
 if __name__ == "__main__":
     if len(sys.argv) > 1:
         exec(sys.argv[1])


### PR DESCRIPTION
expand_dims has the potential to hold more metadata than a plain reshape and has cleaner axis-type propagation semantics
