### PR TITLE
oversubscribe: helps distributed tests if the machine doesn't have 2 slots

### DIFF
--- a/test/test_distributed.py
+++ b/test/test_distributed.py
@@ -52,6 +52,7 @@ def run_test_with_mpi(num_ranks, f, *args):
     check_call([
         "mpiexec", "-np", str(num_ranks),
         "-x", "RUN_WITHIN_MPI=1",
+        "--oversubscribe",
         "-x", f"INVOCATION_INFO={invocation_info}",
         sys.executable, __file__])
 


### PR DESCRIPTION
Helps in avoiding CI failures like: https://github.com/inducer/loopy/runs/6852724847?check_suite_focus=true

```
2022-06-12T22:00:13.1219744Z Traceback (most recent call last):
2022-06-12T22:00:13.1271883Z   File "/home/runner/work/loopy/loopy/pytato/test/test_distributed.py", line 248, in test_dag_with_no_comm_nodes
2022-06-12T22:00:13.1272584Z     run_test_with_mpi(2, _test_dag_with_no_comm_nodes_inner)
2022-06-12T22:00:13.1273231Z   File "/home/runner/work/loopy/loopy/pytato/test/test_distributed.py", line 52, in run_test_with_mpi
2022-06-12T22:00:13.1273781Z     check_call([
2022-06-12T22:00:13.1274683Z   File "/home/runner/work/loopy/loopy/pytato/.miniforge3/envs/testing/lib/python3.10/subprocess.py", line 369, in check_call
2022-06-12T22:00:13.1275363Z     raise CalledProcessError(retcode, cmd)
2022-06-12T22:00:13.1277850Z subprocess.CalledProcessError: Command '['mpiexec', '-np', '2', '-x', 'RUN_WITHIN_MPI=1', '-x', 'INVOCATION_INFO=gASVPgAAAAAAAACMEHRlc3RfZGlzdHJpYnV0ZWSUjCJfdGVzdF9kYWdfd2l0aF9ub19jb21tX25vZGVzX2lubmVylJOUKYaULg==', '/home/runner/work/loopy/loopy/pytato/.miniforge3/envs/testing/bin/python3', '/home/runner/work/loopy/loopy/pytato/test/test_distributed.py']' returned non-zero exit status 1.
2022-06-12T22:00:13.1279783Z ----------------------------- Captured stderr call -----------------------------
2022-06-12T22:00:13.1280609Z --------------------------------------------------------------------------
2022-06-12T22:00:13.1281250Z There are not enough slots available in the system to satisfy the 2
2022-06-12T22:00:13.1281808Z slots that were requested by the application:
2022-06-12T22:00:13.1282113Z 
2022-06-12T22:00:13.1282425Z   /home/runner/work/loopy/loopy/pytato/.miniforge3/envs/testing/bin/python3
2022-06-12T22:00:13.1282779Z 
2022-06-12T22:00:13.1283064Z Either request fewer slots for your application, or make more slots
2022-06-12T22:00:13.1283545Z available for use.
2022-06-12T22:00:13.1283778Z 
2022-06-12T22:00:13.1284054Z A "slot" is the Open MPI term for an allocatable unit where we can
2022-06-12T22:00:13.1284873Z launch a process.  The number of slots available are defined by the
2022-06-12T22:00:13.1285439Z environment in which Open MPI processes are run:
2022-06-12T22:00:13.1285733Z 
2022-06-12T22:00:13.1285987Z   1. Hostfile, via "slots=N" clauses (N defaults to number of
2022-06-12T22:00:13.1286497Z      processor cores if not provided)
2022-06-12T22:00:13.1287245Z   2. The --host command line parameter, via a ":N" suffix on the
2022-06-12T22:00:13.1287755Z      hostname (N defaults to 1 if not provided)
2022-06-12T22:00:13.1288279Z   3. Resource manager (e.g., SLURM, PBS/Torque, LSF, etc.)
2022-06-12T22:00:13.1289017Z   4. If none of a hostfile, the --host command line parameter, or an
2022-06-12T22:00:13.1289612Z      RM is present, Open MPI defaults to the number of processor cores
2022-06-12T22:00:13.1289957Z 
2022-06-12T22:00:13.1290234Z In all the above cases, if you want Open MPI to default to the number
2022-06-12T22:00:13.1290848Z of hardware threads instead of the number of processor cores, use the
2022-06-12T22:00:13.1291489Z --use-hwthread-cpus option.
2022-06-12T22:00:13.1291759Z 
2022-06-12T22:00:13.1292179Z Alternatively, you can use the --oversubscribe option to ignore the
2022-06-12T22:00:13.1292816Z number of available slots when deciding the number of processes to
2022-06-12T22:00:13.1293287Z launch.
2022-06-12T22:00:13.1293916Z --------------------------------------------------------------------------
2022-06-12T22:00:13.1294523Z _______________________ test_distributed_execution_basic _______________________
2022-06-12T22:00:13.1295385Z [gw1] linux -- Python 3.10.4 /home/runner/work/loopy/loopy/pytato/.miniforge3/envs/testing/bin/python3
```