### PR TITLE
Gets rid of all of bare type-ignores in pytato.array

### DIFF
--- a/pytato/array.py
+++ b/pytato/array.py
@@ -153,7 +153,7 @@ Internal stuff that is only here because the documentation tool wants it
 # }}}
 
 from abc import ABC, abstractmethod, abstractproperty
-from functools import partialmethod
+from functools import partialmethod, cached_property
 import operator
 from dataclasses import dataclass
 from typing import (
@@ -249,11 +249,13 @@ def normalize_shape(
         return s
 
     from numbers import Number
+    import collections
+
     if isinstance(shape, (Array, Number)):
         shape = shape,
 
-    # https://github.com/python/mypy/issues/3186
-    return tuple(normalize_shape_component(s) for s in shape)  # type: ignore
+    assert isinstance(shape, collections.abc.Sequence)
+    return tuple(normalize_shape_component(s) for s in shape)
 
 # }}}
 
@@ -273,7 +275,7 @@ def _np_result_type(
         # our dtype:
         *arrays_and_dtypes: DtypeOrScalar,
         ) -> np.dtype[Any]:
-    return np.result_type(*arrays_and_dtypes)  # type: ignore
+    return np.result_type(*arrays_and_dtypes)
 
 
 def _truediv_result_type(arg1: DtypeOrScalar, arg2: DtypeOrScalar) -> np.dtype[Any]:
@@ -453,7 +455,7 @@ class Array(Taggable):
     @property
     def size(self) -> ShapeComponent:
         from pytools import product
-        return product(self.shape)  # type: ignore
+        return product(self.shape)  # type: ignore[no-any-return]
 
     @property
     def dtype(self) -> np.dtype[Any]:
@@ -536,11 +538,14 @@ class Array(Taggable):
 
         import pytato.utils as utils
         if reverse:
-            return utils.broadcast_binary_op(other, self, op,
-                                             get_result_type)  # type: ignore
+            result = utils.broadcast_binary_op(other, self, op,
+                                               get_result_type)
         else:
-            return utils.broadcast_binary_op(self, other, op,
-                                             get_result_type)  # type: ignore
+            result = utils.broadcast_binary_op(self, other, op,
+                                               get_result_type)
+
+        assert isinstance(result, Array)
+        return result
 
     def _unary_op(self, op: Any) -> Array:
         if self.ndim == 0:
@@ -622,7 +627,7 @@ class Array(Taggable):
 
         # type-ignore reason: passed: "Tuple[Union[int, Sequence[int]], ...]";
         # expected "Union[int, Sequence[int]]"
-        return pt.reshape(self, shape, order=order)  # type: ignore
+        return pt.reshape(self, shape, order=order)  # type: ignore[arg-type]
 
     def all(self, axis: int = 0) -> ArrayOrScalar:
         """
@@ -1017,9 +1022,7 @@ class Einsum(Array):
 
         return Map(descr_to_axis_len)
 
-    # type-ignore reason: github.com/python/mypy/issues/1362
-    @property  # type: ignore
-    @memoize_method
+    @cached_property
     def shape(self) -> ShapeType:
         iaxis_to_len: Dict[int, ShapeComponent] = {}
 
@@ -1035,9 +1038,7 @@ class Einsum(Array):
         assert all(i in iaxis_to_len for i in range(len(iaxis_to_len)))
         return tuple(iaxis_to_len[i] for i in range(len(iaxis_to_len)))
 
-    # type-ignore reason: github.com/python/mypy/issues/1362
-    @property  # type: ignore
-    @memoize_method
+    @cached_property
     def dtype(self) -> np.dtype[Any]:
         return np.find_common_type(array_types=[arg.dtype for arg in self.args],
                                     scalar_types=[])
@@ -2160,8 +2161,7 @@ def full(shape: ConvertibleToShape, fill_value: ScalarType,
 
     shape = normalize_shape(shape)
 
-    # https://github.com/python/mypy/issues/3186
-    if np.isnan(fill_value):  # type: ignore[arg-type]
+    if np.isnan(fill_value):
         from pymbolic.primitives import NaN
         fill_value = NaN(dtype.type)
     else:
@@ -2380,10 +2380,13 @@ def logical_or(x1: ArrayOrScalar, x2: ArrayOrScalar) -> Union[Array, bool]:
     Returns the element-wise logical OR of *x1* and *x2*.
     """
     # https://github.com/python/mypy/issues/3186
+    # type-ignored because 'broadcast_binary_op' returns Scalar, while
+    # '_compare' returns a bool.
     import pytato.utils as utils
     return utils.broadcast_binary_op(x1, x2,
                                      lambda x, y: prim.LogicalOr((x, y)),
-                                     lambda x, y: np.bool8)  # type: ignore
+                                     lambda x, y: np.dtype(np.bool8)
+                                     )  # type: ignore[return-value]
 
 
 def logical_and(x1: ArrayOrScalar, x2: ArrayOrScalar) -> Union[Array, bool]:
@@ -2391,10 +2394,13 @@ def logical_and(x1: ArrayOrScalar, x2: ArrayOrScalar) -> Union[Array, bool]:
     Returns the element-wise logical AND of *x1* and *x2*.
     """
     # https://github.com/python/mypy/issues/3186
+    # type-ignored because 'broadcast_binary_op' returns Scalar, while
+    # '_compare' returns a bool.
     import pytato.utils as utils
     return utils.broadcast_binary_op(x1, x2,
                                      lambda x, y: prim.LogicalAnd((x, y)),
-                                     lambda x, y: np.bool8)  # type: ignore
+                                     lambda x, y: np.dtype(np.bool8)
+                                     )  # type: ignore[return-value]
 
 
 def logical_not(x: ArrayOrScalar) -> Union[Array, bool]:
@@ -2403,7 +2409,7 @@ def logical_not(x: ArrayOrScalar) -> Union[Array, bool]:
     """
     if isinstance(x, SCALAR_CLASSES):
         # https://github.com/python/mypy/issues/3186
-        return np.logical_not(x)  # type: ignore
+        return np.logical_not(x)  # type: ignore[no-any-return]
 
     assert isinstance(x, Array)
 
@@ -2443,7 +2449,8 @@ def where(condition: ArrayOrScalar,
 
     if (isinstance(condition, SCALAR_CLASSES) and isinstance(x, SCALAR_CLASSES)
             and isinstance(y, SCALAR_CLASSES)):
-        return x if condition else y  # type: ignore
+        # https://github.com/python/mypy/issues/3186
+        return x if condition else y  # type: ignore[no-any-return]
 
     # {{{ find dtype
 
@@ -2488,8 +2495,7 @@ def maximum(x1: ArrayOrScalar, x2: ArrayOrScalar) -> ArrayOrScalar:
     if (np.issubdtype(common_dtype, np.floating)
             or np.issubdtype(common_dtype, np.complexfloating)):
         from pytato.cmath import isnan
-        # https://github.com/python/mypy/issues/3186
-        return where(logical_or(isnan(x1), isnan(x2)),  # type: ignore
+        return where(logical_or(isnan(x1), isnan(x2)),
                      common_dtype.type(np.NaN),
                      where(greater(x1, x2), x1, x2))
     else:
@@ -2507,8 +2513,7 @@ def minimum(x1: ArrayOrScalar, x2: ArrayOrScalar) -> ArrayOrScalar:
     if (np.issubdtype(common_dtype, np.floating)
             or np.issubdtype(common_dtype, np.complexfloating)):
         from pytato.cmath import isnan
-        # https://github.com/python/mypy/issues/3186
-        return where(logical_or(isnan(x1), isnan(x2)),  # type: ignore
+        return where(logical_or(isnan(x1), isnan(x2)),
                      common_dtype.type(np.NaN),
                      where(less(x1, x2), x1, x2))
     else:
@@ -2582,8 +2587,7 @@ def dot(a: ArrayOrScalar, b: ArrayOrScalar) -> ArrayOrScalar:
     import pytato as pt
 
     if isinstance(a, SCALAR_CLASSES) or isinstance(b, SCALAR_CLASSES):
-        # type-ignored because Number * bool is undefined
-        return a * b  # type: ignore
+        return a * b
 
     assert isinstance(a, Array)
     assert isinstance(b, Array)

--- a/pytato/cmath.py
+++ b/pytato/cmath.py
@@ -120,95 +120,111 @@ def _apply_elem_wise_func(inputs: Tuple[ArrayOrScalar, ...],
     )
 
 
-def abs(x: Array) -> ArrayOrScalar:
-    if x.dtype.kind == "c":
-        result_dtype = np.empty(0, dtype=x.dtype).real.dtype
+def _get_dtype(x: ArrayOrScalar) -> _dtype_any:
+    if isinstance(x, Array):
+        return x.dtype
     else:
-        result_dtype = x.dtype
+        assert isinstance(x, SCALAR_CLASSES)
+        return np.dtype(type(x))
+
+
+def abs(x: ArrayOrScalar) -> ArrayOrScalar:
+    x_dtype = _get_dtype(x)
+    if x_dtype.kind == "c":
+        result_dtype = np.empty(0, dtype=x_dtype).real.dtype
+    else:
+        result_dtype = x_dtype
 
     return _apply_elem_wise_func((x,), "abs", ret_dtype=result_dtype)
 
 
-def sqrt(x: Array) -> ArrayOrScalar:
+def sqrt(x: ArrayOrScalar) -> ArrayOrScalar:
     return _apply_elem_wise_func((x,), "sqrt")
 
 
-def sin(x: Array) -> ArrayOrScalar:
+def sin(x: ArrayOrScalar) -> ArrayOrScalar:
     return _apply_elem_wise_func((x,), "sin")
 
 
-def cos(x: Array) -> ArrayOrScalar:
+def cos(x: ArrayOrScalar) -> ArrayOrScalar:
     return _apply_elem_wise_func((x,), "cos")
 
 
-def tan(x: Array) -> ArrayOrScalar:
+def tan(x: ArrayOrScalar) -> ArrayOrScalar:
     return _apply_elem_wise_func((x,), "tan")
 
 
-def arcsin(x: Array) -> ArrayOrScalar:
+def arcsin(x: ArrayOrScalar) -> ArrayOrScalar:
     return _apply_elem_wise_func((x,), "asin", np_func_name="arcsin")
 
 
-def arccos(x: Array) -> ArrayOrScalar:
+def arccos(x: ArrayOrScalar) -> ArrayOrScalar:
     return _apply_elem_wise_func((x,), "acos", np_func_name="arccos")
 
 
-def arctan(x: Array) -> ArrayOrScalar:
+def arctan(x: ArrayOrScalar) -> ArrayOrScalar:
     return _apply_elem_wise_func((x,), "atan", np_func_name="arctan")
 
 
-def conj(x: Array) -> ArrayOrScalar:
-    if x.dtype.kind != "c":
+def conj(x: ArrayOrScalar) -> ArrayOrScalar:
+    if _get_dtype(x).kind != "c":
         return x
     return _apply_elem_wise_func((x,), "conj")
 
 
-def arctan2(y: Array, x: Array) -> ArrayOrScalar:
+def arctan2(y: ArrayOrScalar, x: ArrayOrScalar) -> ArrayOrScalar:
     return _apply_elem_wise_func((y, x), "atan2", np_func_name="arctan2")
 
 
-def sinh(x: Array) -> ArrayOrScalar:
+def sinh(x: ArrayOrScalar) -> ArrayOrScalar:
     return _apply_elem_wise_func((x,), "sinh")
 
 
-def cosh(x: Array) -> ArrayOrScalar:
+def cosh(x: ArrayOrScalar) -> ArrayOrScalar:
     return _apply_elem_wise_func((x,), "cosh")
 
 
-def tanh(x: Array) -> ArrayOrScalar:
+def tanh(x: ArrayOrScalar) -> ArrayOrScalar:
     return _apply_elem_wise_func((x,), "tanh")
 
 
-def exp(x: Array) -> ArrayOrScalar:
+def exp(x: ArrayOrScalar) -> ArrayOrScalar:
     return _apply_elem_wise_func((x,), "exp")
 
 
-def log(x: Array) -> ArrayOrScalar:
+def log(x: ArrayOrScalar) -> ArrayOrScalar:
     return _apply_elem_wise_func((x,), "log")
 
 
-def log10(x: Array) -> ArrayOrScalar:
+def log10(x: ArrayOrScalar) -> ArrayOrScalar:
     return _apply_elem_wise_func((x,), "log10")
 
 
-def isnan(x: Array) -> ArrayOrScalar:
+def isnan(x: ArrayOrScalar) -> ArrayOrScalar:
     return _apply_elem_wise_func((x,), "isnan", np.dtype(np.int32))
 
 
-def real(x: Array) -> ArrayOrScalar:
-    if x.dtype.kind == "c":
-        result_dtype = np.empty(0, dtype=x.dtype).real.dtype
+def real(x: ArrayOrScalar) -> ArrayOrScalar:
+    x_dtype = _get_dtype(x)
+    if x_dtype.kind == "c":
+        result_dtype = np.empty(0, dtype=x_dtype).real.dtype
     else:
         return x
     return _apply_elem_wise_func((x,), "real", ret_dtype=result_dtype)
 
 
-def imag(x: Array) -> ArrayOrScalar:
-    if x.dtype.kind == "c":
-        result_dtype = np.empty(0, dtype=x.dtype).real.dtype
+def imag(x: ArrayOrScalar) -> ArrayOrScalar:
+    x_dtype = _get_dtype(x)
+    if x_dtype.kind == "c":
+        result_dtype = np.empty(0, dtype=x_dtype).real.dtype
     else:
-        import pytato as pt
-        return pt.zeros(x.shape, dtype=x.dtype)
+        if np.isscalar(x):
+            # numpy does specialize it enough.
+            return x_dtype.type(0)  # type: ignore[no-any-return]
+        else:
+            assert isinstance(x, Array)
+            import pytato as pt
+            return pt.zeros(x.shape, dtype=x_dtype)
     return _apply_elem_wise_func((x,), "imag", ret_dtype=result_dtype)
 
 # vim: fdm=marker

--- a/pytato/scalar_expr.py
+++ b/pytato/scalar_expr.py
@@ -24,7 +24,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
-from numbers import Number
 from typing import (
         Any, Union, Mapping, FrozenSet, Set, Tuple, Optional, TYPE_CHECKING,
         Iterable)
@@ -71,13 +70,11 @@ __doc__ = """
 
 # {{{ scalar expressions
 
-IntegralT = Union[int, np.int8, np.int16, np.int32, np.int64, np.uint8,
-                  np.uint16, np.uint32, np.uint64]
+IntegralT = Union[int, np.integer]
 BoolT = Union[bool, np.bool8]
-INT_CLASSES = (int, np.int8, np.int16, np.int32, np.int64, np.uint8,
-               np.uint16, np.uint32, np.uint64)
+INT_CLASSES = (int, np.integer)
 IntegralScalarExpression = Union[IntegralT, prim.Expression]
-ScalarType = Union[Number, int, np.bool_, bool, float]
+ScalarType = Union[np.number, int, np.bool_, bool, float]
 ScalarExpression = Union[ScalarType, prim.Expression]
 SCALAR_CLASSES = prim.VALID_CONSTANT_CLASSES
 


### PR DESCRIPTION
- uses np.number/np.integer for all numpy types
- Makes pytato.cmath functions take in ArrayOrScalar as input operands