### PR TITLE
MPI Examples Github CI: Enable oversubscribe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
                 build_py_project_in_conda_env
                 run_examples
 
-                mpirun -n 2 python distributed.py
+                mpirun -n 2 --oversubscribe python distributed.py
 
     docs:
         name: Documentation


### PR DESCRIPTION
Addresses this recent CI failure: https://github.com/inducer/pytato/runs/8055146793?check_suite_focus=true#step:3:697