### PR TITLE
Use ~~dataclasses~~ attrs for pt.Array

### DIFF
--- a/.pylintrc-local.yml
+++ b/.pylintrc-local.yml
@@ -6,3 +6,11 @@
   - ply
   - pygments.lexers
   - pygments.formatters
+
+# https://github.com/PyCQA/pylint/issues/7623
+- arg: disable
+  val:
+    - unexpected-keyword-arg
+    - too-many-function-args
+    - redundant-keyword-arg
+    - no-value-for-parameter

--- a/pytato/codegen.py
+++ b/pytato/codegen.py
@@ -121,7 +121,7 @@ class CodeGenPreprocessor(CopyMapper):
     def map_size_param(self, expr: SizeParam) -> Array:
         name = expr.name
         assert name is not None
-        return SizeParam(name=name, tags=expr.tags)
+        return SizeParam(name, tags=expr.tags)
 
     def map_placeholder(self, expr: Placeholder) -> Array:
         name = expr.name

--- a/pytato/loopy.py
+++ b/pytato/loopy.py
@@ -167,16 +167,20 @@ class LoopyCallResult(NamedArray):
 
     @property
     def shape(self) -> ShapeType:
-        loopy_arg = self._container._entry_kernel.arg_dict[  # type:ignore
-                self.name]
-        shape: ShapeType = self._container._to_pytato(  # type:ignore
+        # pylint: disable=E1101
+        # reason: (pylint doesn't respect the asserts)
+        assert isinstance(self._container, LoopyCall)
+        loopy_arg = self._container._entry_kernel.arg_dict[self.name]
+        shape: ShapeType = self._container._to_pytato(  # type:ignore[assignment]
                 loopy_arg.shape)
         return shape
 
     @property
     def dtype(self) -> np.dtype[Any]:
-        loopy_arg = self._container._entry_kernel.arg_dict[  # type:ignore
-                self.name]
+        # pylint: disable=E1101
+        # reason: (pylint doesn't respect the asserts)
+        assert isinstance(self._container, LoopyCall)
+        loopy_arg = self._container._entry_kernel.arg_dict[self.name]
         return np.dtype(loopy_arg.dtype.numpy_dtype)
 
 

--- a/pytato/partition.py
+++ b/pytato/partition.py
@@ -26,7 +26,7 @@ THE SOFTWARE.
 
 from typing import (Any, Callable, Dict, Union, Set, List, Hashable, Tuple, TypeVar,
         FrozenSet, Mapping, Optional, Type)
-from dataclasses import dataclass
+import attrs
 
 import logging
 logger = logging.getLogger(__name__)
@@ -240,7 +240,7 @@ class GraphPartitioner(EdgeCachedMapper):
 
 # {{{ graph partition
 
-@dataclass(frozen=True)
+@attrs.define(frozen=True, slots=False)
 class GraphPart:
     """
     .. attribute:: pid
@@ -284,7 +284,7 @@ class GraphPart:
         return self.user_input_names | self. partition_input_names
 
 
-@dataclass(frozen=True)
+@attrs.define(frozen=True, slots=False)
 class GraphPartition:
     """Store information about a partitioning of an expression graph.
 

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
         "pytools>=2021.1",
         "pyrsistent",
         "immutables",
+        "attrs",
         ],
     package_data={"pytato": ["py.typed"]},
     author="Andreas Kloeckner, Matt Wala, Xiaoyu Wei",

--- a/test/test_pytato.py
+++ b/test/test_pytato.py
@@ -775,7 +775,9 @@ def test_deduplicate_data_wrappers():
 
     a = pt.make_data_wrapper(np.arange(27))
     b = pt.make_data_wrapper(np.arange(27))
-    c = pt.make_data_wrapper(a.data.view())
+    # pylint-disable-reason: pylint is correct, DataInterface doesn't declare a
+    # view method, but for numpy-like arrays it should be OK.
+    c = pt.make_data_wrapper(a.data.view())   # pylint: disable=E1101
     d = pt.make_data_wrapper(np.arange(1, 28))
 
     res = a+b+c+d


### PR DESCRIPTION
Pros:
- Immutable types (`frozen=True`)
- Derived classes can be dataclasses (noticed while implementing #364)
- In almost all cases uses the generated `__init__`.

Cons:
- All derived classes must do `eq=False` in their call to `dataclass`, otherwise `dataclasses` will implement its own default which has a complexity of $O(2^N)$ in number of nodes in the DAG.
- All derived classes must do `def __hash__(self) -> int: return super().__hash__()`, otherwise `dataclasses` will implement its own default.
- Constructor arguments have to be `_shape`, `_dtype` instead of `shape`, `dtype` as `pt.Array` already has properties of that name.
- :warning: Pylint Failures.