### PR TITLE
Make AbstractResultWithNamedArrays taggable

### DIFF
--- a/pytato/array.py
+++ b/pytato/array.py
@@ -736,7 +736,8 @@ class NamedArray(Array):
         return self.expr.dtype
 
 
-class AbstractResultWithNamedArrays(Mapping[str, NamedArray], ABC):
+@attrs.define(frozen=True, eq=False)
+class AbstractResultWithNamedArrays(Mapping[str, NamedArray], Taggable, ABC):
     r"""An abstract array computation that results in multiple :class:`Array`\ s,
     each named. The way in which the values of these arrays are computed
     is determined by concrete subclasses of this class, e.g.
@@ -751,7 +752,7 @@ class AbstractResultWithNamedArrays(Mapping[str, NamedArray], ABC):
 
         This container deliberately does not implement arithmetic.
     """
-
+    tags: FrozenSet[Tag] = attrs.field(kw_only=True)
     _mapper_method: ClassVar[str]
 
     @abstractmethod
@@ -767,6 +768,7 @@ class AbstractResultWithNamedArrays(Mapping[str, NamedArray], ABC):
         pass
 
 
+@attrs.define(frozen=True, eq=False)
 class DictOfNamedArrays(AbstractResultWithNamedArrays):
     """A container of named results, each of which can be computed as an
     array expression provided to the constructor.
@@ -775,12 +777,9 @@ class DictOfNamedArrays(AbstractResultWithNamedArrays):
 
     .. automethod:: __init__
     """
+    _data: Mapping[str, Array]
 
     _mapper_method: ClassVar[str] = "map_dict_of_named_arrays"
-
-    def __init__(self, data: Mapping[str, Array]):
-        super().__init__()
-        self._data = data
 
     def __hash__(self) -> int:
         return hash(frozenset(self._data.items()))

--- a/pytato/array.py
+++ b/pytato/array.py
@@ -768,7 +768,7 @@ class AbstractResultWithNamedArrays(Mapping[str, NamedArray], Taggable, ABC):
         pass
 
 
-@attrs.define(frozen=True, eq=False)
+@attrs.define(frozen=True, eq=False, init=False)
 class DictOfNamedArrays(AbstractResultWithNamedArrays):
     """A container of named results, each of which can be computed as an
     array expression provided to the constructor.
@@ -780,6 +780,18 @@ class DictOfNamedArrays(AbstractResultWithNamedArrays):
     _data: Mapping[str, Array]
 
     _mapper_method: ClassVar[str] = "map_dict_of_named_arrays"
+
+    def __init__(self, data: Mapping[str, Array], *,
+                 tags: Optional[FrozenSet[Tag]] = None) -> None:
+        if tags is None:
+            from warnings import warn
+            warn("Passing `tags=None` is deprecated and will result"
+                 " in an error from 2023. To remove this message either"
+                 " call make_dict_of_named_arrays or pass the `tags` argument.")
+            tags = frozenset()
+
+        object.__setattr__(self, "_data", data)
+        object.__setattr__(self, "tags", tags)
 
     def __hash__(self) -> int:
         return hash(frozenset(self._data.items()))

--- a/pytato/array.py
+++ b/pytato/array.py
@@ -1976,12 +1976,14 @@ def reshape(array: Array, newshape: Union[int, Sequence[int]],
 
 # {{{ make_dict_of_named_arrays
 
-def make_dict_of_named_arrays(data: Dict[str, Array]) -> DictOfNamedArrays:
+def make_dict_of_named_arrays(data: Dict[str, Array], *,
+                              tags: FrozenSet[Tag] = frozenset()
+                              ) -> DictOfNamedArrays:
     """Make a :class:`DictOfNamedArrays` object.
 
     :param data: member keys and arrays
     """
-    return DictOfNamedArrays(data)
+    return DictOfNamedArrays(data, tags=(tags | _get_default_tags()))
 
 # }}}
 

--- a/pytato/codegen.py
+++ b/pytato/codegen.py
@@ -36,7 +36,7 @@ from pytato.array import (Array, DictOfNamedArrays, IndexLambda,
                           InputArgumentBase, Einsum,
                           AdvancedIndexInContiguousAxes,
                           AdvancedIndexInNoncontiguousAxes, BasicIndex,
-                          NormalizedSlice)
+                          NormalizedSlice, make_dict_of_named_arrays)
 
 from pytato.scalar_expr import (ScalarExpression, IntegralScalarExpression,
                                 INT_CLASSES, IntegralT)
@@ -183,7 +183,9 @@ class CodeGenPreprocessor(CopyMapper):
 
         return LoopyCall(translation_unit=translation_unit,
                          bindings=bindings,
-                         entrypoint=entrypoint)
+                         entrypoint=entrypoint,
+                         tags=expr.tags
+                         )
 
     def map_data_wrapper(self, expr: DataWrapper) -> Array:
         name = _generate_name_for_temp(expr, self.var_name_gen, "_pt_data")
@@ -616,9 +618,9 @@ def normalize_outputs(result: Union[Array, DictOfNamedArrays,
                 "either an Array or a DictOfNamedArrays")
 
     if isinstance(result, Array):
-        outputs = DictOfNamedArrays({"_pt_out": result})
+        outputs = make_dict_of_named_arrays({"_pt_out": result})
     elif isinstance(result, dict):
-        outputs = DictOfNamedArrays(result)
+        outputs = make_dict_of_named_arrays(result)
     else:
         assert isinstance(result, DictOfNamedArrays)
         outputs = result

--- a/pytato/loopy.py
+++ b/pytato/loopy.py
@@ -207,6 +207,8 @@ def call_loopy(translation_unit: "lp.TranslationUnit",
       to :class:`pytato.array.Array`.
     :arg entrypoint: the entrypoint of the ``translation_unit`` parameter.
     """
+    from pytato.array import _get_default_tags
+
     if entrypoint is None:
         if len(translation_unit.entrypoints) != 1:
             raise ValueError("cannot infer entrypoint")
@@ -285,7 +287,8 @@ def call_loopy(translation_unit: "lp.TranslationUnit",
 
     translation_unit = translation_unit.with_entrypoints(frozenset())
 
-    return LoopyCall(translation_unit, bindings, entrypoint)
+    return LoopyCall(translation_unit, bindings, entrypoint,
+                     tags=_get_default_tags())
 
 
 # {{{ shape inference

--- a/pytato/partition.py
+++ b/pytato/partition.py
@@ -35,7 +35,7 @@ from pytools import memoize_method
 from pytato.transform import EdgeCachedMapper, CachedWalkMapper
 from pytato.array import (
         Array, AbstractResultWithNamedArrays, Placeholder,
-        DictOfNamedArrays, make_placeholder)
+        DictOfNamedArrays, make_placeholder, make_dict_of_named_arrays)
 
 from pytato.target import BoundProgram
 
@@ -359,7 +359,7 @@ def find_partition(outputs: DictOfNamedArrays,
         _check_partition_disjointness(result)
 
     from pytato.analysis import get_num_nodes
-    num_nodes_per_part = [get_num_nodes(DictOfNamedArrays(
+    num_nodes_per_part = [get_num_nodes(make_dict_of_named_arrays(
             {x: result.var_name_to_result[x] for x in part.output_names}))
             for part in result.parts.values()]
 
@@ -423,7 +423,7 @@ def generate_code_for_partition(partition: GraphPartition) \
 
     for part in sorted(partition.parts.values(),
                        key=lambda part_: sorted(part_.output_names)):
-        d = DictOfNamedArrays(
+        d = make_dict_of_named_arrays(
                     {var_name: partition.var_name_to_result[var_name]
                         for var_name in part.output_names
                      })

--- a/test/test_codegen.py
+++ b/test/test_codegen.py
@@ -183,7 +183,7 @@ def test_codegen_with_DictOfNamedArrays(ctx_factory):  # noqa
     x_in = np.array([1, 2, 3, 4, 5])
     y_in = np.array([6, 7, 8, 9, 10])
 
-    result = pt.DictOfNamedArrays(dict(x_out=x, y_out=y))
+    result = pt.make_dict_of_named_arrays(dict(x_out=x, y_out=y))
 
     # With return_dict.
     prog = pt.generate_loopy(result)
@@ -525,7 +525,7 @@ def test_dict_of_named_array_codegen_avoids_recomputation():
     y = 2*x
     z = y + 4*x
 
-    yz = pt.DictOfNamedArrays({"y": y, "z": z})
+    yz = pt.make_dict_of_named_arrays({"y": y, "z": z})
 
     knl = pt.generate_loopy(yz).kernel
     assert ("y" in knl.id_to_insn["z_store"].read_dependency_names())
@@ -750,7 +750,7 @@ def test_call_loopy_with_same_callee_names(ctx_factory):
     cuatro_u = 2*call_loopy(twice, {"x": u}, "callee")["y"]
     nueve_u = 3*call_loopy(thrice, {"x": u}, "callee")["y"]
 
-    out = pt.DictOfNamedArrays({"cuatro_u": cuatro_u, "nueve_u": nueve_u})
+    out = pt.make_dict_of_named_arrays({"cuatro_u": cuatro_u, "nueve_u": nueve_u})
 
     evt, out_dict = pt.generate_loopy(out,
                                       options=lp.Options(return_dict=True))(queue)
@@ -1376,7 +1376,7 @@ def test_random_dag_against_numpy(ctx_factory):
             ref_result = make_random_dag(rdagc_np)
             dag = make_random_dag(rdagc_pt)
             from pytato.transform import materialize_with_mpms
-            dict_named_arys = pt.DictOfNamedArrays({"result": dag})
+            dict_named_arys = pt.make_dict_of_named_arrays({"result": dag})
             dict_named_arys = materialize_with_mpms(dict_named_arys)
             if 0:
                 pt.show_dot_graph(dict_named_arys)
@@ -1407,7 +1407,7 @@ def test_partitioner(ctx_factory):
         ref_result = make_random_dag(rdagc_np)
 
         from pytato.transform import materialize_with_mpms
-        dict_named_arys = materialize_with_mpms(pt.DictOfNamedArrays(
+        dict_named_arys = materialize_with_mpms(pt.make_dict_of_named_arrays(
                 {"result": make_random_dag(rdagc_pt)}))
 
         from dataclasses import dataclass

--- a/test/test_distributed.py
+++ b/test/test_distributed.py
@@ -92,7 +92,7 @@ def _do_test_distributed_execution_basic(ctx_factory):
     y = x+halo
 
     # Find the partition
-    outputs = pt.DictOfNamedArrays({"out": y})
+    outputs = pt.make_dict_of_named_arrays({"out": y})
     distributed_parts = find_distributed_partition(outputs)
     prg_per_partition = generate_code_for_partition(distributed_parts)
 
@@ -167,7 +167,8 @@ def _do_test_distributed_execution_random_dag(ctx_factory):
                 additional_generators=[
                     (comm_fake_prob, gen_comm)
                     ])
-        pt_dag = pt.DictOfNamedArrays({"result": make_random_dag(rdagc_comm)})
+        pt_dag = pt.make_dict_of_named_arrays(
+            {"result": make_random_dag(rdagc_comm)})
         x_comm = pt.transform.materialize_with_mpms(pt_dag)
 
         distributed_partition = find_distributed_partition(x_comm)

--- a/test/test_jax.py
+++ b/test/test_jax.py
@@ -102,7 +102,7 @@ def test_random_dag_against_numpy(jit):
             ref_result = make_random_dag(rdagc_np)
             dag = make_random_dag(rdagc_pt)
             from pytato.transform import materialize_with_mpms
-            dict_named_arys = pt.DictOfNamedArrays({"result": dag})
+            dict_named_arys = pt.make_dict_of_named_arrays({"result": dag})
             dict_named_arys = materialize_with_mpms(dict_named_arys)
             if 0:
                 pt.show_dot_graph(dict_named_arys)


### PR DESCRIPTION
Metadata on AbstractResultsWithNamedArrays could come in handy. For eg. in #364, one might want to tag the `Call` with implementation tags (like InlineTag) as directives for the call-site.