### PR TITLE
Fix return type annotation of `Axis._with_new_tag`

### DIFF
--- a/pytato/array.py
+++ b/pytato/array.py
@@ -327,7 +327,7 @@ class Axis(Taggable):
     """
     tags: FrozenSet[Tag]
 
-    def _with_new_tags(self, tags: FrozenSet[Tag]) -> Taggable:
+    def _with_new_tags(self, tags: FrozenSet[Tag]) -> Axis:
         from attrs import evolve as replace
         return replace(self, tags=tags)
 


### PR DESCRIPTION
Example CI failure: https://gitlab.tiker.net/inducer/pytato/-/jobs/482487