### PR TITLE
pyrsistent -> immutables

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -26,7 +26,6 @@ intersphinx_mapping = {
     "https://documen.tician.de/loopy/": None,
     "https://documen.tician.de/sumpy/": None,
     "https://documen.tician.de/islpy/": None,
-    "https://pyrsistent.readthedocs.io/en/latest/": None,
     "https://jax.readthedocs.io/en/latest/": None,
     "https://www.attrs.org/en/stable/": None,
 }
@@ -45,7 +44,6 @@ sys._BUILDING_SPHINX_DOCS = True
 
 nitpick_ignore_regex = [
     ["py:class", r"numpy.(u?)int[\d]+"],
-    ["py:class", r"pyrsistent.typing.(.+)"],
     ["py:class", r"typing_extensions(.+)"],
     # As of 2022-10-20, it doesn't look like there's sphinx documentation
     # available.

--- a/pytato/loopy.py
+++ b/pytato/loopy.py
@@ -38,7 +38,7 @@ from pytato.scalar_expr import (SubstitutionMapper, ScalarExpression,
                                 EvaluationMapper, IntegralT)
 from pytools import memoize_method
 from pytools.tag import Tag
-from pyrsistent import PMap, pmap
+from immutables import Map
 import islpy as isl
 
 __doc__ = r"""
@@ -222,7 +222,7 @@ def call_loopy(translation_unit: "lp.TranslationUnit",
     # {{{ perform shape inference here
 
     bindings = extend_bindings_with_shape_inference(translation_unit[entrypoint],
-                                                    pmap(bindings))
+                                                    Map(bindings))
 
     # }}}
 
@@ -388,7 +388,7 @@ def _get_pt_dim_expr(dim: Union[IntegralT, Array]) -> ScalarExpression:
 
 
 def extend_bindings_with_shape_inference(knl: lp.LoopKernel,
-                                         bindings: PMap[str, ArrayOrScalar]
+                                         bindings: Map[str, ArrayOrScalar]
                                          ) -> Dict[str, ArrayOrScalar]:
     from functools import reduce
     from loopy.symbolic import get_dependencies as lpy_get_deps

--- a/pytato/raising.py
+++ b/pytato/raising.py
@@ -11,8 +11,7 @@ from pytato.utils import (get_indexing_expression,
 from pytato.scalar_expr import ScalarType, ScalarExpression, Reduce, SCALAR_CLASSES
 from pytato.reductions import ReductionOperation
 from dataclasses import dataclass
-from pyrsistent import pmap
-from pyrsistent.typing import PMap
+from immutables import Map
 
 
 __doc__ = """
@@ -102,7 +101,7 @@ class ReduceOp(HighLevelOp):
     """
     op: ReductionOperation
     x: Array
-    axes: PMap[int, str]
+    axes: Map[int, str]
 
 # }}}
 
@@ -320,12 +319,12 @@ def index_lambda_to_high_level_op(expr: IndexLambda) -> HighLevelOp:
                                       .expr
                                       .inner_expr
                                       .aggregate.name],
-                        axes=pmap({i: idx.name
-                                   for i, idx in enumerate(expr
-                                                           .expr
-                                                           .inner_expr
-                                                           .index_tuple)
-                                   if idx.name in expr.expr.bounds})
+                        axes=Map({i: idx.name
+                                  for i, idx in enumerate(expr
+                                                          .expr
+                                                          .inner_expr
+                                                          .index_tuple)
+                                  if idx.name in expr.expr.bounds})
                         )
 
     if _is_idx_lambda_broadcast_op(expr):

--- a/pytato/stringifier.py
+++ b/pytato/stringifier.py
@@ -31,7 +31,7 @@ from pytato.transform import Mapper
 from pytato.array import (Array, DataWrapper, DictOfNamedArrays, Axis,
                           IndexLambda, ReductionDescriptor)
 from pytato.loopy import LoopyCall
-from pyrsistent import PMap
+from immutables import Map
 
 
 __doc__ = """
@@ -76,7 +76,7 @@ class Reprifier(Mapper):
     def map_foreign(self, expr: Any, depth: int) -> str:  # type: ignore[override]
         if isinstance(expr, tuple):
             return "(" + ", ".join(self.rec(el, depth) for el in expr) + ")"
-        elif isinstance(expr, (dict, PMap)):
+        elif isinstance(expr, (dict, Map)):
             return ("{"
                     + ", ".join(f"{key!r}: {self.rec(val, depth)}"
                                 for key, val in expr.items())

--- a/pytato/target/python/numpy_like.py
+++ b/pytato/target/python/numpy_like.py
@@ -38,6 +38,7 @@ from pytato.array import (Stack, Concatenate, IndexLambda, DataWrapper,
                           Reshape, Array, DictOfNamedArrays, IndexBase,
                           DataInterface, NormalizedSlice, ShapeComponent,
                           IndexExpr, ArrayOrScalar)
+from immutables import Map
 from pytato.scalar_expr import SCALAR_CLASSES
 from pytato.utils import are_shape_components_equal
 from pytato.raising import BinaryOpType, C99CallOp
@@ -48,7 +49,6 @@ from pytato.reductions import (ReductionOperation, SumReductionOperation,
                                ProductReductionOperation,
                                MaxReductionOperation, MinReductionOperation,
                                AllReductionOperation, AnyReductionOperation)
-from pyrsistent import pmap
 
 
 T = TypeVar("T")
@@ -598,4 +598,4 @@ def generate_numpy_like(expr: Union[Array, Mapping[str, Array], DictOfNamedArray
         program,
         function_name,
         expected_arguments=frozenset(cgen_mapper.arg_names),
-        bound_arguments=pmap(cgen_mapper.bound_arguments))
+        bound_arguments=Map(cgen_mapper.bound_arguments))

--- a/pytato/transform/__init__.py
+++ b/pytato/transform/__init__.py
@@ -44,8 +44,7 @@ from pytato.array import (
 from pytato.loopy import LoopyCall, LoopyCallResult
 from dataclasses import dataclass
 from pytato.tags import ImplStored
-from pyrsistent import pmap
-from pyrsistent.typing import PMap as PMapT
+from immutables import Map
 
 if TYPE_CHECKING:
     from pytato.distributed import DistributedSendRefHolder, DistributedRecv
@@ -1465,7 +1464,7 @@ def get_users(expr: ArrayOrNames) -> Dict[ArrayOrNames,
 # {{{ operations on graphs in dict form
 
 def reverse_graph(graph: Mapping[ArrayOrNames, FrozenSet[ArrayOrNames]]
-                  ) -> PMapT[ArrayOrNames, FrozenSet[ArrayOrNames]]:
+                  ) -> Map[ArrayOrNames, FrozenSet[ArrayOrNames]]:
     """
     Reverses a graph.
 
@@ -1473,7 +1472,7 @@ def reverse_graph(graph: Mapping[ArrayOrNames, FrozenSet[ArrayOrNames]]
         node to other nodes to which it is connected by edges. A possible
         use case for this function is the graph in
         :attr:`UsersCollector.node_to_users`.
-    :returns: A :class:`pyrsistent.PMap` representing *graph* with edges reversed.
+    :returns: A :class:`immutables.Map` representing *graph* with edges reversed.
     """
     result: Dict[ArrayOrNames, Set[ArrayOrNames]] = {}
 
@@ -1484,7 +1483,7 @@ def reverse_graph(graph: Mapping[ArrayOrNames, FrozenSet[ArrayOrNames]]
         for other_node_key in edges:
             result.setdefault(other_node_key, set()).add(node_key)
 
-    return pmap({k: frozenset(v) for k, v in result.items()})
+    return Map({k: frozenset(v) for k, v in result.items()})
 
 
 def _recursively_get_all_users(

--- a/pytato/utils.py
+++ b/pytato/utils.py
@@ -38,7 +38,7 @@ from pytato.scalar_expr import (ScalarExpression, IntegralScalarExpression,
                                 SCALAR_CLASSES, INT_CLASSES, BoolT)
 from pytools import UniqueNameGenerator
 from pytato.transform import Mapper
-from pyrsistent import pmap
+from immutables import Map
 
 
 __doc__ = """
@@ -206,7 +206,7 @@ def broadcast_binary_op(a1: ArrayOrScalar, a2: ArrayOrScalar,
                        dtype=result_dtype,
                        bindings=bindings,
                        tags=_get_default_tags(),
-                       var_to_reduction_descr=pmap(),
+                       var_to_reduction_descr=Map(),
                        axes=_get_default_axes(len(result_shape)))
 
 

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,6 @@ setup(
     install_requires=[
         "loopy>=2020.2",
         "pytools>=2021.1",
-        "pyrsistent",
         "immutables",
         "attrs",
         ],

--- a/test/test_pytato.py
+++ b/test/test_pytato.py
@@ -335,7 +335,7 @@ def test_userscollector():
     rev_graph = reverse_graph(uc.node_to_users)
     rev_graph2 = reverse_graph(reverse_graph(rev_graph))
 
-    assert reverse_graph(rev_graph2) == uc.node_to_users
+    assert dict(reverse_graph(rev_graph2)) == uc.node_to_users
 
     # Test random DAGs
     axis_len = 5
@@ -698,9 +698,10 @@ def test_basic_index_equality_traverses_underlying_arrays():
 
 def test_idx_lambda_to_hlo():
     from pytato.raising import index_lambda_to_high_level_op
+    from immutables import Map
     from pytato.raising import (BinaryOp, BinaryOpType, FullOp, ReduceOp,
                                 C99CallOp, BroadcastOp)
-    from pyrsistent import pmap
+
     from pytato.reductions import (SumReductionOperation,
                                    ProductReductionOperation)
 
@@ -740,12 +741,12 @@ def test_idx_lambda_to_hlo():
     assert (index_lambda_to_high_level_op(pt.sum(b, axis=1))
             == ReduceOp(SumReductionOperation(),
                         b,
-                        pmap({1: "_r0"})))
+                        Map({1: "_r0"})))
     assert (index_lambda_to_high_level_op(pt.prod(a))
             == ReduceOp(ProductReductionOperation(),
                         a,
-                        {0: "_r0",
-                         1: "_r1"}))
+                        Map({0: "_r0",
+                             1: "_r1"})))
     assert index_lambda_to_high_level_op(pt.sinh(a)) == C99CallOp("sinh", (a,))
     assert index_lambda_to_high_level_op(pt.arctan2(b, a)) == C99CallOp("atan2",
                                                                         (b, a))


### PR DESCRIPTION
Made this change to discourage different code patterns like `pmap(dict) | Map(dict)` and force `Map(dict)`. This should lead to more homogeneous code patterns. After this patch, we should see --

```
[line@line pytato]$ git grep pyrsistent | wc
      0       0       0
``` 