### PR TITLE
[mypy]: mypy-0.990 caught an incorrect subtype method signature

### DIFF
--- a/pytato/loopy.py
+++ b/pytato/loopy.py
@@ -149,6 +149,7 @@ class LoopyCallResult(NamedArray):
                                axes=axes,
                                tags=tags)
 
+    @property
     def expr(self) -> Array:
         raise ValueError("Expressions for results of loopy functions aren't defined")
 


### PR DESCRIPTION
This was hanging around in #387. Decided not to hold other PRs for it.