### PR TITLE
Make the parametric type of CachedMapper to be the return type

### DIFF
--- a/pytato/codegen.py
+++ b/pytato/codegen.py
@@ -83,7 +83,8 @@ def _generate_name_for_temp(
 
 # {{{ preprocessing for codegen
 
-class CodeGenPreprocessor(ToIndexLambdaMixin, CopyMapper):
+# type-ignore-reason: incompatible 'rec' types between ToIndexLambdaMixin, CopyMapper
+class CodeGenPreprocessor(ToIndexLambdaMixin, CopyMapper):  # type: ignore[misc]
     """A mapper that preprocesses graphs to simplify code generation.
 
     The following node simplifications are performed:

--- a/pytato/distributed/partition.py
+++ b/pytato/distributed/partition.py
@@ -50,7 +50,7 @@ from pytato.array import (Array,
                           NamedArray)
 from pytato.transform import (ArrayOrNames, CopyMapper, Mapper,
                               CachedWalkMapper, CopyMapperWithExtraArgs,
-                              CombineMapper)
+                              CombineMapper, CopyMapperResultT)
 from pytato.partition import GraphPart, GraphPartition, PartId, GraphPartitioner
 from pytato.distributed.nodes import (
         DistributedRecv, DistributedSend, DistributedSendRefHolder)
@@ -233,10 +233,12 @@ class _DistributedGraphPartitioner(GraphPartitioner):
     def map_distributed_send_ref_holder(
                 self, expr: DistributedSendRefHolder, *args: Any) -> Any:
         send_part_id = self.get_part_id(expr.send.data)
+        rec_send_data = self.rec(expr.send.data)
+        assert isinstance(rec_send_data, Array)
 
         self.pid_to_dist_sends.setdefault(send_part_id, []).append(
                 DistributedSend(
-                    data=self.rec(expr.send.data),
+                    data=rec_send_data,
                     dest_rank=expr.send.dest_rank,
                     comm_tag=expr.send.comm_tag,
                     tags=expr.send.tags))
@@ -560,7 +562,7 @@ class _PartIDTagAssigner(CopyMapperWithExtraArgs):
 
         # type-ignore reason: incompatible  attribute type wrt base.
         self._cache: Dict[Tuple[ArrayOrNames, int],
-                          Any] = {}  # type: ignore[assignment]
+                          ArrayOrNames] = {}  # type: ignore[assignment]
 
     # type-ignore-reason: incompatible with super class
     def get_cache_key(self,  # type: ignore[override]
@@ -572,11 +574,12 @@ class _PartIDTagAssigner(CopyMapperWithExtraArgs):
 
     # type-ignore-reason: incompatible with super class
     def rec(self,  # type: ignore[override]
-            expr: ArrayOrNames,
-            user_part_id: int) -> Any:
+            expr: CopyMapperResultT,
+            user_part_id: int) -> CopyMapperResultT:
         key = self.get_cache_key(expr, user_part_id)
         try:
-            return self._cache[key]
+            # type-ignore-reason: parametric dicts are not a thing in typing module
+            return self._cache[key]  # type: ignore[return-value]
         except KeyError:
             if isinstance(expr, Array):
                 if expr in self.stored_array_to_part_id:
@@ -591,6 +594,12 @@ class _PartIDTagAssigner(CopyMapperWithExtraArgs):
             result = super().rec(expr, user_part_id)
             self._cache[key] = result
             return result
+
+    # type-ignore-reason: incompatible with super class
+    def __call__(self,  # type: ignore[override]
+                 expr: CopyMapperResultT,
+                 user_part_id: int) -> CopyMapperResultT:
+        return self.rec(expr, user_part_id)
 
 
 def _remove_part_id_tag(ary: ArrayOrNames) -> Array:

--- a/pytato/partition.py
+++ b/pytato/partition.py
@@ -161,7 +161,10 @@ class GraphPartitioner(EdgeCachedMapper):
                                       tags=child.tags,
                                       axes=child.axes)
 
-                self.var_name_to_result[ph_name] = self.rec(child)
+                # type-ignore-reason: mypy is right, types of self.rec are
+                # imprecise (TODO)
+                self.var_name_to_result[ph_name] = (
+                    self.rec(child))  # type: ignore[assignment]
 
                 self._seen_node_to_placeholder[child] = ph
 

--- a/pytato/target/python/numpy_like.py
+++ b/pytato/target/python/numpy_like.py
@@ -31,7 +31,7 @@ from typing import (Callable, Union, Optional, Mapping, Dict, TypeVar, Iterable,
                     cast, List, Set, Tuple, Type)
 
 from pytools import UniqueNameGenerator
-from pytato.transform import CachedMapper, ArrayOrNames
+from pytato.transform import CachedMapper
 from pytato.array import (Stack, Concatenate, IndexLambda, DataWrapper,
                           Placeholder, SizeParam, Roll,
                           AxisPermutation, Einsum,
@@ -164,7 +164,7 @@ PYTATO_REDUCTION_TO_NP_REDUCTION: Mapping[Type[ReductionOperation], str] = {
 }
 
 
-class NumpyCodegenMapper(CachedMapper[ArrayOrNames]):
+class NumpyCodegenMapper(CachedMapper[str]):
     """
     .. note::
 
@@ -408,7 +408,7 @@ class NumpyCodegenMapper(CachedMapper[ArrayOrNames]):
         )
 
         if last_non_trivial_index == -1:
-            return self.rec(expr.array)  # type: ignore[no-any-return]
+            return self.rec(expr.array)
 
         lhs = self.vng("_pt_tmp")
 
@@ -500,8 +500,7 @@ class NumpyCodegenMapper(CachedMapper[ArrayOrNames]):
         return self._record_line_and_return_lhs(lhs, rhs)
 
     def map_named_array(self, expr: NamedArray) -> str:
-        # type-ignore-reason: CachedMapper.rec's types are imprecise
-        return self.rec(expr.expr)  # type: ignore[no-any-return]
+        return self.rec(expr.expr)
 
     def map_dict_of_named_arrays(self, expr: DictOfNamedArrays) -> str:
         lhs = self.vng("_pt_tmp")

--- a/pytato/transform/remove_broadcasts_einsum.py
+++ b/pytato/transform/remove_broadcasts_einsum.py
@@ -96,8 +96,6 @@ def rewrite_einsums_with_no_broadcasts(expr: MappedT) -> MappedT:
         alter its value.
     """
     mapper = EinsumWithNoBroadcastsRewriter()
-
-    # type-ignore-reason: mypy is right i.e. CopyMapper.__call__ is imprecise
-    return mapper(expr)  # type: ignore[no-any-return]
+    return mapper(expr)
 
 # vim:fdm=marker


### PR DESCRIPTION
Before this patch, the parametric type in CachedMapper denoted the input type of the mapper which is unnecessary as the input type is always `ArrayOrNames`.

I think https://github.com/inducer/pytato/issues/409 is also talking about this same thing.