### PR TITLE
Eliminate recursive forwarding in mappers

### DIFF
--- a/pytato/target/loopy/codegen.py
+++ b/pytato/target/loopy/codegen.py
@@ -34,7 +34,7 @@ import pymbolic.primitives as prim
 from pymbolic import var
 
 from typing import (Union, Optional, Mapping, Dict, Tuple, FrozenSet, Set,
-                    Any, List, Type)
+                    Any, List, Type, TYPE_CHECKING)
 
 
 from pytato.array import (Array, DictOfNamedArrays, ShapeType, IndexLambda,
@@ -623,6 +623,13 @@ class InlinedExpressionGenMapper(scalar_expr.IdentityMapper):
 
     def __init__(self, codegen_mapper: CodeGenMapper):
         self.codegen_mapper = codegen_mapper
+
+    if TYPE_CHECKING:
+        def __call__(self, expr: ScalarExpression,
+                     prstnt_ctx: PersistentExpressionContext,
+                     local_ctx: Optional[LocalExpressionContext],
+                     ) -> ScalarExpression:
+            return self.rec(expr, prstnt_ctx, local_ctx)
 
     def map_subscript(self, expr: prim.Subscript,
                       prstnt_ctx: PersistentExpressionContext,

--- a/pytato/target/loopy/codegen.py
+++ b/pytato/target/loopy/codegen.py
@@ -624,12 +624,6 @@ class InlinedExpressionGenMapper(scalar_expr.IdentityMapper):
     def __init__(self, codegen_mapper: CodeGenMapper):
         self.codegen_mapper = codegen_mapper
 
-    def __call__(self, expr: ScalarExpression,
-                 prstnt_ctx: PersistentExpressionContext,
-                 local_ctx: Optional[LocalExpressionContext],
-                 ) -> ScalarExpression:
-        return self.rec(expr, prstnt_ctx, local_ctx)
-
     def map_subscript(self, expr: prim.Subscript,
                       prstnt_ctx: PersistentExpressionContext,
                       local_ctx: LocalExpressionContext,

--- a/pytato/transform/__init__.py
+++ b/pytato/transform/__init__.py
@@ -32,7 +32,7 @@ import logging
 import numpy as np
 from immutables import Map
 from typing import (Any, Callable, Dict, FrozenSet, Union, TypeVar, Set, Generic,
-                    List, Mapping, Iterable, Tuple, Optional,
+                    List, Mapping, Iterable, Tuple, Optional, TYPE_CHECKING,
                     Hashable)
 
 from pytato.array import (
@@ -215,6 +215,12 @@ class CachedMapper(Mapper, Generic[CachedMapperT]):
             # type-ignore-reason: Mapper.rec has imprecise func. signature
             return result  # type: ignore[no-any-return]
 
+    if TYPE_CHECKING:
+        # type-ignore-reason: incompatible with super class
+        def __call__(self, expr: ArrayOrNames  # type: ignore[override]
+                     ) -> CachedMapperT:
+            return self.rec(expr)
+
 # }}}
 
 
@@ -231,6 +237,14 @@ class CopyMapper(CachedMapper[ArrayOrNames]):
 
        This does not copy the data of a :class:`pytato.array.DataWrapper`.
     """
+    if TYPE_CHECKING:
+        # type-ignore-reason: specialized variant of super-class' rec method
+        def rec(self,  # type: ignore[override]
+                expr: CopyMapperResultT) -> CopyMapperResultT:
+            # type-ignore-reason: CachedMapper.rec's return type is imprecise
+            return super().rec(expr)  # type: ignore[return-value]
+
+        __call__ = rec
 
     def clone_for_callee(self: _SelfMapper) -> _SelfMapper:
         """
@@ -1214,6 +1228,9 @@ class CachedMapAndCopyMapper(CopyMapper):
         self._cache[expr] = result
         # type-ignore-reason: map_fn has imprecise types
         return result  # type: ignore[return-value]
+
+    if TYPE_CHECKING:
+        __call__ = rec
 
 # }}}
 

--- a/pytato/transform/__init__.py
+++ b/pytato/transform/__init__.py
@@ -185,9 +185,7 @@ class Mapper:
         assert method is not None
         return method(expr, *args, **kwargs)
 
-    def __call__(self, expr: MappedT, *args: Any, **kwargs: Any) -> Any:
-        """Handle the mapping of *expr*."""
-        return self.rec(expr, *args, **kwargs)
+    __call__ = rec
 
 # }}}
 
@@ -217,11 +215,6 @@ class CachedMapper(Mapper, Generic[CachedMapperT]):
             # type-ignore-reason: Mapper.rec has imprecise func. signature
             return result  # type: ignore[no-any-return]
 
-    # type-ignore-reason: incompatible with super class
-    def __call__(self, expr: ArrayOrNames  # type: ignore[override]
-                 ) -> CachedMapperT:
-        return self.rec(expr)
-
 # }}}
 
 
@@ -238,17 +231,6 @@ class CopyMapper(CachedMapper[ArrayOrNames]):
 
        This does not copy the data of a :class:`pytato.array.DataWrapper`.
     """
-
-    # type-ignore-reason: specialized variant of super-class' rec method
-    def rec(self,  # type: ignore[override]
-            expr: CopyMapperResultT) -> CopyMapperResultT:
-        # type-ignore-reason: CachedMapper.rec's return type is imprecise
-        return super().rec(expr)  # type: ignore[return-value]
-
-    # type-ignore-reason: specialized variant of super-class' rec method
-    def __call__(self,  # type: ignore[override]
-                 expr: CopyMapperResultT) -> CopyMapperResultT:
-        return self.rec(expr)
 
     def clone_for_callee(self: _SelfMapper) -> _SelfMapper:
         """
@@ -1232,10 +1214,6 @@ class CachedMapAndCopyMapper(CopyMapper):
         self._cache[expr] = result
         # type-ignore-reason: map_fn has imprecise types
         return result  # type: ignore[return-value]
-
-    # type-ignore-reason: Mapper.__call__ returns Any
-    def __call__(self, expr: MappedT) -> MappedT:  # type: ignore[override]
-        return self.rec(expr)
 
 # }}}
 

--- a/pytato/transform/lower_to_index_lambda.py
+++ b/pytato/transform/lower_to_index_lambda.py
@@ -28,7 +28,7 @@ THE SOFTWARE.
 
 import pymbolic.primitives as prim
 
-from typing import List, Any, Dict, Tuple, TypeVar
+from typing import List, Any, Dict, Tuple, TypeVar, TYPE_CHECKING
 from immutables import Map
 from pytools import UniqueNameGenerator
 from pytato.array import (Array, IndexLambda, Stack, Concatenate,
@@ -82,6 +82,15 @@ class ToIndexLambdaMixin:
         return tuple(self.rec(s) if isinstance(s, Array)
                      else s
                      for s in shape)
+
+    if TYPE_CHECKING:
+        def rec(
+                self, expr: ToIndexLambdaT, *args: Any,
+                **kwargs: Any) -> ToIndexLambdaT:
+            # type-ignore-reason: mypy is right as we are attempting to make
+            # guarantees about other super-classes.
+            return super().rec(  # type: ignore[no-any-return,misc]
+                expr, *args, **kwargs)
 
     def map_index_lambda(self, expr: IndexLambda) -> IndexLambda:
         return IndexLambda(expr=expr.expr,

--- a/pytato/transform/lower_to_index_lambda.py
+++ b/pytato/transform/lower_to_index_lambda.py
@@ -83,11 +83,6 @@ class ToIndexLambdaMixin:
                      else s
                      for s in shape)
 
-    def rec(self, expr: ToIndexLambdaT, *args: Any, **kwargs: Any) -> ToIndexLambdaT:
-        # type-ignore-reason: mypy is right as we are attempting to make
-        # guarantees about other super-classes.
-        return super().rec(expr, *args, **kwargs)  # type: ignore[no-any-return,misc]
-
     def map_index_lambda(self, expr: IndexLambda) -> IndexLambda:
         return IndexLambda(expr=expr.expr,
                            shape=self._rec_shape(expr.shape),


### PR DESCRIPTION
@inducer Turns out I didn't revert these changes after all, I just wasn't looking far enough down the commit list. 🙂

(I'll submit the `InlinedExpressionGenMapper` changes as a separate PR since they're a little less trivial.)