### PR TITLE
Pass-through is the more appropriate spelling for the adjective.

### DIFF
--- a/pytato/transform/metadata.py
+++ b/pytato/transform/metadata.py
@@ -529,7 +529,7 @@ class AxesTagsEquationCollector(Mapper):
         is the value held by
         :attr:`pytato.DistributedSendRefHolder.passthrough_data`, equality
         equations are added between each axis of *expr* and its corresponding
-        axis in the passthrough data.
+        axis in the pass-through data.
         """
         self.rec(expr.passthrough_data)
         self.rec(expr.send.data)


### PR DESCRIPTION
You are supposed to use pass-through for the adjective when it is directly next to the noun.