### PR TITLE
Define `__attrs_post_init__` only if `__debug__`, for all `Array` classes

### DIFF
--- a/pytato/array.py
+++ b/pytato/array.py
@@ -745,10 +745,11 @@ class AbstractResultWithNamedArrays(Mapping[str, NamedArray], Taggable, ABC):
     def _is_eq_valid(self) -> bool:
         return self.__class__.__eq__ is AbstractResultWithNamedArrays.__eq__
 
-    def __attrs_post_init__(self) -> None:
-        # ensure that a developer does not uses dataclass' "__eq__"
-        # or "__hash__" implementation as they have exponential complexity.
-        assert self._is_eq_valid()
+    if __debug__:
+        def __attrs_post_init__(self) -> None:
+            # ensure that a developer does not uses dataclass' "__eq__"
+            # or "__hash__" implementation as they have exponential complexity.
+            assert self._is_eq_valid()
 
     @abstractmethod
     def __contains__(self, name: object) -> bool:
@@ -1450,10 +1451,11 @@ class Reshape(IndexRemappingBase):
 
     _mapper_method: ClassVar[str] = "map_reshape"
 
-    def __attrs_post_init__(self) -> None:
-        # FIXME: Get rid of this restriction
-        assert self.order == "C"
-        super().__attrs_post_init__()
+    if __debug__:
+        def __attrs_post_init__(self) -> None:
+            # FIXME: Get rid of this restriction
+            assert self.order == "C"
+            super().__attrs_post_init__()
 
     @property
     def shape(self) -> ShapeType:

--- a/pytato/function.py
+++ b/pytato/function.py
@@ -276,11 +276,12 @@ class Call(AbstractResultWithNamedArrays):
 
     copy = attrs.evolve
 
-    def __attrs_post_init__(self) -> None:
-        # check that the invocation parameters and the function definition
-        # parameters agree with each other.
-        assert frozenset(self.bindings) == self.function.parameters
-        super().__attrs_post_init__()
+    if __debug__:
+        def __attrs_post_init__(self) -> None:
+            # check that the invocation parameters and the function definition
+            # parameters agree with each other.
+            assert frozenset(self.bindings) == self.function.parameters
+            super().__attrs_post_init__()
 
     def __contains__(self, name: object) -> bool:
         return name in self.function.returns


### PR DESCRIPTION
Follow-on to #452, noticed by @mtcam after attempting to pytato code with `-O`.