### PR TITLE
replace immutables.Map with immutabledict

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -46,9 +46,9 @@ sys._BUILDING_SPHINX_DOCS = True
 nitpick_ignore_regex = [
     ["py:class", r"numpy.(u?)int[\d]+"],
     ["py:class", r"typing_extensions(.+)"],
-    # As of 2022-10-20, it doesn't look like there's sphinx documentation
+    # As of 2023-10-05, it doesn't look like there's sphinx documentation
     # available.
-    ["py:class", r"immutables\.(.+)"],
+    ["py:class", r"immutabledict(.*)"],
     # https://github.com/python-attrs/attrs/issues/1073
     ["py:mod", "attrs"],
 ]

--- a/pytato/array.py
+++ b/pytato/array.py
@@ -556,7 +556,7 @@ class Array(Taggable):
             indices = tuple(var(f"_{i}") for i in range(self.ndim))
             expr = op(var("_in0")[indices])
 
-        bindings: immutabledict[str, Array] = immutabledict({"_in0": self})
+        bindings: Mapping[str, Array] = immutabledict({"_in0": self})
         return IndexLambda(
                 expr=expr,
                 shape=self.shape,
@@ -1128,9 +1128,9 @@ def _normalize_einsum_out_subscript(subscript: str) -> immutabledict[str,
 
 def _normalize_einsum_in_subscript(subscript: str,
                                    in_operand: Array,
-                                   index_to_descr: immutabledict[str,
+                                   index_to_descr: Mapping[str,
                                                         EinsumAxisDescriptor],
-                                   index_to_axis_length: immutabledict[str,
+                                   index_to_axis_length: Mapping[str,
                                                                ShapeComponent],
                                    ) -> Tuple[Tuple[EinsumAxisDescriptor, ...],
                                               immutabledict
@@ -1245,7 +1245,7 @@ def einsum(subscripts: str, *operands: Array,
         )
 
     index_to_descr = _normalize_einsum_out_subscript(out_spec)
-    index_to_axis_length: immutabledict[str, ShapeComponent] = immutabledict()
+    index_to_axis_length: Mapping[str, ShapeComponent] = immutabledict()
     access_descriptors = []
 
     for in_spec, in_operand in zip(in_specs, operands):

--- a/pytato/cmath.py
+++ b/pytato/cmath.py
@@ -62,7 +62,7 @@ from pytato.array import (Array, ArrayOrScalar, IndexLambda, _dtype_any,
                           _get_default_axes, _get_default_tags)
 from pytato.scalar_expr import SCALAR_CLASSES
 from pymbolic import var
-from immutables import Map
+from immutabledict import immutabledict
 
 
 def _apply_elem_wise_func(inputs: Tuple[ArrayOrScalar, ...],
@@ -113,10 +113,10 @@ def _apply_elem_wise_func(inputs: Tuple[ArrayOrScalar, ...],
     return IndexLambda(
         expr=prim.Call(var(f"pytato.c99.{func_name}"),
                   tuple(sym_args)),
-        shape=shape, dtype=ret_dtype, bindings=Map(bindings),
+        shape=shape, dtype=ret_dtype, bindings=immutabledict(bindings),
         tags=_get_default_tags(),
         axes=_get_default_axes(len(shape)),
-        var_to_reduction_descr=Map(),
+        var_to_reduction_descr=immutabledict(),
     )
 
 

--- a/pytato/codegen.py
+++ b/pytato/codegen.py
@@ -24,6 +24,7 @@ THE SOFTWARE.
 
 import dataclasses
 from typing import Union, Dict, Tuple, List, Any, Optional
+from immutabledict import immutabledict
 
 from pytato.array import (Array, DictOfNamedArrays, DataWrapper, Placeholder,
                           DataInterface, SizeParam, InputArgumentBase,
@@ -173,9 +174,10 @@ class CodeGenPreprocessor(ToIndexLambdaMixin, CopyMapper):  # type: ignore[misc]
 
         # }}}
 
-        bindings = {name: (self.rec(subexpr) if isinstance(subexpr, Array)
+        bindings: immutabledict[str, Any] = immutabledict(
+                    {name: (self.rec(subexpr) if isinstance(subexpr, Array)
                            else subexpr)
-                    for name, subexpr in sorted(expr.bindings.items())}
+                    for name, subexpr in sorted(expr.bindings.items())})
 
         return LoopyCall(translation_unit=translation_unit,
                          bindings=bindings,
@@ -282,8 +284,8 @@ def preprocess(outputs: DictOfNamedArrays, target: Target) -> PreprocessResult:
                                                 for out in outputs.values()))
 
     # only look for dependencies between the outputs
-    deps = {name: get_deps(output.expr)
-            for name, output in outputs.items()}
+    deps: immutabledict[str, Any] = immutabledict({name: get_deps(output.expr)
+            for name, output in outputs.items()})
 
     # represent deps in terms of output names
     output_expr_to_name = {output.expr: name for name, output in outputs.items()}

--- a/pytato/codegen.py
+++ b/pytato/codegen.py
@@ -23,7 +23,7 @@ THE SOFTWARE.
 """
 
 import dataclasses
-from typing import Union, Dict, Tuple, List, Any, Optional
+from typing import Union, Dict, Tuple, List, Any, Optional, Mapping
 from immutabledict import immutabledict
 
 from pytato.array import (Array, DictOfNamedArrays, DataWrapper, Placeholder,
@@ -174,7 +174,7 @@ class CodeGenPreprocessor(ToIndexLambdaMixin, CopyMapper):  # type: ignore[misc]
 
         # }}}
 
-        bindings: immutabledict[str, Any] = immutabledict(
+        bindings: Mapping[str, Any] = immutabledict(
                     {name: (self.rec(subexpr) if isinstance(subexpr, Array)
                            else subexpr)
                     for name, subexpr in sorted(expr.bindings.items())})
@@ -284,7 +284,7 @@ def preprocess(outputs: DictOfNamedArrays, target: Target) -> PreprocessResult:
                                                 for out in outputs.values()))
 
     # only look for dependencies between the outputs
-    deps: immutabledict[str, Any] = immutabledict({name: get_deps(output.expr)
+    deps: Mapping[str, Any] = immutabledict({name: get_deps(output.expr)
             for name, output in outputs.items()})
 
     # represent deps in terms of output names

--- a/pytato/distributed/partition.py
+++ b/pytato/distributed/partition.py
@@ -68,7 +68,7 @@ from typing import (
         List, AbstractSet, TypeVar, TYPE_CHECKING, Hashable, Optional)
 
 import attrs
-from immutables import Map
+from immutabledict import immutabledict
 
 from pytools.graph import CycleError
 from pytools import memoize_method
@@ -405,11 +405,11 @@ def _make_distributed_partition(
                 partition_input_names=frozenset(
                     comm_replacer.partition_input_name_to_placeholder.keys()),
                 output_names=frozenset(name_to_ouput.keys()),
-                name_to_recv_node=Map({
+                name_to_recv_node=immutabledict({
                     recvd_ary_to_name[local_recv_id_to_recv_node[recv_id]]:
                     local_recv_id_to_recv_node[recv_id]
                     for recv_id in comm_ids.recv_ids}),
-                name_to_send_nodes=Map(name_to_send_nodes))
+                name_to_send_nodes=immutabledict(name_to_send_nodes))
 
     result = DistributedGraphPartition(
             parts=parts,

--- a/pytato/function.py
+++ b/pytato/function.py
@@ -49,7 +49,7 @@ import enum
 
 from typing import (Callable, Dict, FrozenSet, Tuple, Union, TypeVar, Optional,
                     Hashable, Sequence, ClassVar, Iterator, Iterable, Mapping)
-from immutables import Map
+from immutabledict import immutabledict
 from functools import cached_property
 from pytato.array import (Array,  AbstractResultWithNamedArrays,
                           Placeholder, NamedArray, ShapeType, _dtype_any,
@@ -126,7 +126,7 @@ class FunctionDefinition(Taggable):
     """
     parameters: FrozenSet[str]
     return_type: ReturnType
-    returns: Map[str, Array]
+    returns: immutabledict[str, Array]
     tags: FrozenSet[Tag] = attrs.field(kw_only=True)
 
     @cached_property
@@ -142,7 +142,7 @@ class FunctionDefinition(Taggable):
             frozenset()
         )
 
-        return Map({input_arg.name: input_arg
+        return immutabledict({input_arg.name: input_arg
                     for input_arg in all_input_args
                     if isinstance(input_arg, Placeholder)})
 
@@ -188,7 +188,8 @@ class FunctionDefinition(Taggable):
 
         # }}}
 
-        call_site = Call(self, bindings=Map(kwargs), tags=_get_default_tags())
+        call_site = Call(self, bindings=immutabledict(kwargs),
+                         tags=_get_default_tags())
 
         if self.return_type == ReturnType.ARRAY:
             return call_site["_"]
@@ -253,7 +254,7 @@ class NamedCallResult(NamedArray):
         return self._container.function.returns[self.name].dtype
 
 
-# eq=False to avoid equality comparison without EqualityMaper
+# eq=False to avoid equality comparison without EqualityMapper
 @attrs.define(frozen=True, eq=False, hash=True, cache_hash=True, repr=False)
 class Call(AbstractResultWithNamedArrays):
     """
@@ -270,7 +271,7 @@ class Call(AbstractResultWithNamedArrays):
 
     """
     function: FunctionDefinition
-    bindings: Map[str, Array]
+    bindings: immutabledict[str, Array]
 
     _mapper_method: ClassVar[str] = "map_call"
 
@@ -371,7 +372,7 @@ def trace_call(f: Callable[..., ReturnT],
     function = FunctionDefinition(
         frozenset(pl_arg.name for pl_arg in pl_args) | frozenset(pl_kwargs),
         return_type,
-        Map(returns),
+        immutabledict(returns),
         tags=_get_default_tags() | (frozenset([FunctionIdentifier(identifier)])
                                     if identifier
                                     else frozenset())

--- a/pytato/function.py
+++ b/pytato/function.py
@@ -126,7 +126,7 @@ class FunctionDefinition(Taggable):
     """
     parameters: FrozenSet[str]
     return_type: ReturnType
-    returns: immutabledict[str, Array]
+    returns: Mapping[str, Array]
     tags: FrozenSet[Tag] = attrs.field(kw_only=True)
 
     @cached_property
@@ -271,7 +271,7 @@ class Call(AbstractResultWithNamedArrays):
 
     """
     function: FunctionDefinition
-    bindings: immutabledict[str, Array]
+    bindings: Mapping[str, Array]
 
     _mapper_method: ClassVar[str] = "map_call"
 

--- a/pytato/loopy.py
+++ b/pytato/loopy.py
@@ -37,7 +37,7 @@ from pytato.array import (AbstractResultWithNamedArrays, Array, ShapeType,
 from pytato.scalar_expr import (SubstitutionMapper, ScalarExpression,
                                 EvaluationMapper, IntegralT)
 from pytools import memoize_method
-from immutables import Map
+from immutabledict import immutabledict
 import islpy as isl
 
 __doc__ = r"""
@@ -78,7 +78,7 @@ class LoopyCall(AbstractResultWithNamedArrays):
     :mod:`loopy` translation unit.
     """
     translation_unit: "lp.TranslationUnit"
-    bindings: Dict[str, ArrayOrScalar]
+    bindings: immutabledict[str, ArrayOrScalar]
     entrypoint: str
 
     _mapper_method: ClassVar[str] = "map_loopy_call"
@@ -212,18 +212,19 @@ def call_loopy(translation_unit: "lp.TranslationUnit",
 
     # {{{ perform shape inference here
 
-    bindings = extend_bindings_with_shape_inference(translation_unit[entrypoint],
-                                                    Map(bindings))
+    bindings_new = extend_bindings_with_shape_inference(translation_unit[entrypoint],
+                                                    immutabledict(bindings))
+    del bindings
 
     # }}}
 
     for arg in translation_unit[entrypoint].args:
         if arg.is_input:
-            if arg.name not in bindings:
+            if arg.name not in bindings_new:
                 raise ValueError(f"Kernel '{entrypoint}' expects an input"
                         f" '{arg.name}'")
 
-            arg_binding = bindings[arg.name]
+            arg_binding = bindings_new[arg.name]
 
             if isinstance(arg, (lp.ArrayArg, lp.ConstantArg)):
                 if not isinstance(arg_binding, Array):
@@ -242,7 +243,7 @@ def call_loopy(translation_unit: "lp.TranslationUnit",
 
     # {{{ infer types of the translation_unit
 
-    for name, ary in bindings.items():
+    for name, ary in bindings_new.items():
         if translation_unit[entrypoint].arg_dict[name].dtype not in [lp.auto,
                                                                      None]:
             continue
@@ -265,7 +266,7 @@ def call_loopy(translation_unit: "lp.TranslationUnit",
 
     translation_unit = translation_unit.with_entrypoints(frozenset())
 
-    return LoopyCall(translation_unit, bindings, entrypoint,
+    return LoopyCall(translation_unit, bindings_new, entrypoint,
                      tags=_get_default_tags())
 
 
@@ -379,8 +380,8 @@ def _get_pt_dim_expr(dim: Union[IntegralT, Array]) -> ScalarExpression:
 
 
 def extend_bindings_with_shape_inference(knl: lp.LoopKernel,
-                                         bindings: Map[str, ArrayOrScalar]
-                                         ) -> Dict[str, ArrayOrScalar]:
+                                         bindings: immutabledict[str, ArrayOrScalar]
+                                         ) -> immutabledict[str, ArrayOrScalar]:
     from functools import reduce
     from loopy.symbolic import get_dependencies as lpy_get_deps
     from loopy.kernel.array import ArrayBase
@@ -478,6 +479,8 @@ def extend_bindings_with_shape_inference(knl: lp.LoopKernel,
     as_pt_size_param = EvaluationMapper({_pt_var_to_global_namespace(arg.name): arg
                                          for arg in pt_size_params})
 
+    bindings_dict = dict(bindings)
+
     for var, val in solutions.items():
         # map the pymbolic expression back into an expression in terms of
         # pt.SizeParams
@@ -494,9 +497,9 @@ def extend_bindings_with_shape_inference(knl: lp.LoopKernel,
 
         # }}}
 
-        bindings = bindings.set(var, val)
+        bindings_dict[var] = val
 
-    return dict(bindings)
+    return immutabledict(bindings_dict)
 
 # }}}
 

--- a/pytato/loopy.py
+++ b/pytato/loopy.py
@@ -78,7 +78,7 @@ class LoopyCall(AbstractResultWithNamedArrays):
     :mod:`loopy` translation unit.
     """
     translation_unit: "lp.TranslationUnit"
-    bindings: immutabledict[str, ArrayOrScalar]
+    bindings: Mapping[str, ArrayOrScalar]
     entrypoint: str
 
     _mapper_method: ClassVar[str] = "map_loopy_call"
@@ -380,7 +380,7 @@ def _get_pt_dim_expr(dim: Union[IntegralT, Array]) -> ScalarExpression:
 
 
 def extend_bindings_with_shape_inference(knl: lp.LoopKernel,
-                                         bindings: immutabledict[str, ArrayOrScalar]
+                                         bindings: Mapping[str, ArrayOrScalar]
                                          ) -> immutabledict[str, ArrayOrScalar]:
     from functools import reduce
     from loopy.symbolic import get_dependencies as lpy_get_deps

--- a/pytato/raising.py
+++ b/pytato/raising.py
@@ -11,7 +11,7 @@ from pytato.utils import (get_indexing_expression,
 from pytato.scalar_expr import ScalarType, ScalarExpression, Reduce, SCALAR_CLASSES
 from pytato.reductions import ReductionOperation
 from dataclasses import dataclass
-from immutables import Map
+from immutabledict import immutabledict
 
 
 __doc__ = """
@@ -101,7 +101,7 @@ class ReduceOp(HighLevelOp):
     """
     op: ReductionOperation
     x: Array
-    axes: Map[int, str]
+    axes: immutabledict[int, str]
 
 # }}}
 
@@ -319,7 +319,7 @@ def index_lambda_to_high_level_op(expr: IndexLambda) -> HighLevelOp:
                                       .expr
                                       .inner_expr
                                       .aggregate.name],
-                        axes=Map({i: idx.name
+                        axes=immutabledict({i: idx.name
                                   for i, idx in enumerate(expr
                                                           .expr
                                                           .inner_expr

--- a/pytato/raising.py
+++ b/pytato/raising.py
@@ -101,7 +101,7 @@ class ReduceOp(HighLevelOp):
     """
     op: ReductionOperation
     x: Array
-    axes: immutabledict[int, str]
+    axes: Mapping[int, str]
 
 # }}}
 

--- a/pytato/reductions.py
+++ b/pytato/reductions.py
@@ -34,7 +34,7 @@ import numpy as np
 
 from pytato.array import ShapeType, Array, make_index_lambda, ReductionDescriptor
 from pytato.scalar_expr import ScalarExpression, Reduce, INT_CLASSES
-from immutables import Map
+from immutabledict import immutabledict
 import pymbolic.primitives as prim
 
 # {{{ docs
@@ -213,7 +213,7 @@ def _get_reduction_indices_bounds(shape: ShapeType,
             indices.append(prim.Variable(f"_{n_out_dims}"))
             n_out_dims += 1
 
-    return indices, Map(redn_bounds)
+    return indices, immutabledict(redn_bounds)
 
 
 def _get_var_to_redn_descr(shape: ShapeType,
@@ -258,7 +258,7 @@ def _get_var_to_redn_descr(shape: ShapeType,
             var_to_redn_descr[idx] = redn_descr
             n_redn_dims += 1
 
-    return Map(var_to_redn_descr)
+    return immutabledict(var_to_redn_descr)
 
 
 def _make_reduction_lambda(

--- a/pytato/scalar_expr.py
+++ b/pytato/scalar_expr.py
@@ -42,7 +42,7 @@ from pymbolic.mapper.stringifier import (StringifyMapper as
         StringifyMapperBase)
 from pymbolic.mapper import CombineMapper as CombineMapperBase
 from pymbolic.mapper.collector import TermCollector as TermCollectorBase
-from immutables import Map
+from immutabledict import immutabledict
 import pymbolic.primitives as prim
 import numpy as np
 import re
@@ -113,7 +113,7 @@ class SubstitutionMapper(SubstitutionMapperBase):
     def map_reduce(self, expr: Reduce) -> ScalarExpression:
         return Reduce(self.rec(expr.inner_expr),
                       op=expr.op,
-                      bounds=Map(
+                      bounds=immutabledict(
                           {name: self.rec(bound)
                            for name, bound in expr.bounds.items()}))
 

--- a/pytato/stringifier.py
+++ b/pytato/stringifier.py
@@ -31,7 +31,7 @@ from pytato.transform import Mapper
 from pytato.array import (Array, DataWrapper, DictOfNamedArrays, Axis,
                           IndexLambda, ReductionDescriptor)
 from pytato.loopy import LoopyCall
-from immutables import Map
+from immutabledict import immutabledict
 import attrs
 
 
@@ -77,7 +77,7 @@ class Reprifier(Mapper):
     def map_foreign(self, expr: Any, depth: int) -> str:  # type: ignore[override]
         if isinstance(expr, tuple):
             return "(" + ", ".join(self.rec(el, depth) for el in expr) + ")"
-        elif isinstance(expr, (dict, Map)):
+        elif isinstance(expr, (dict, immutabledict)):
             return ("{"
                     + ", ".join(f"{key!r}: {self.rec(val, depth)}"
                                 for key, val

--- a/pytato/target/loopy/__init__.py
+++ b/pytato/target/loopy/__init__.py
@@ -137,7 +137,7 @@ class BoundPyOpenCLProgram(BoundProgram):
     """
     program: loopy.TranslationUnit
     _processed_bound_args_cache: Dict[pyopencl.Context,
-                                      immutabledict[str, Any]] = \
+                                      Mapping[str, Any]] = \
                                         field(default_factory=dict)
 
     def copy(self, *,
@@ -170,7 +170,7 @@ class BoundPyOpenCLProgram(BoundProgram):
                                        queue: pyopencl.CommandQueue,
                                        allocator: Optional[Callable[
                                            [int], pyopencl.MemoryObject]],
-                                       ) -> immutabledict[str, Any]:
+                                       ) -> Mapping[str, Any]:
         import pyopencl.array as cla
 
         cache_key = queue.context
@@ -194,7 +194,7 @@ class BoundPyOpenCLProgram(BoundProgram):
                                     " numpy array, pyopencl array or scalar."
                                     f" Got {type(bnd_arg).__name__} for '{name}'.")
 
-            result: immutabledict[str, Any] = immutabledict(proc_bnd_args)
+            result: Mapping[str, Any] = immutabledict(proc_bnd_args)
             assert set(result.keys()) == set(self.bound_arguments.keys())
             self._processed_bound_args_cache[cache_key] = result
             return result

--- a/pytato/target/loopy/__init__.py
+++ b/pytato/target/loopy/__init__.py
@@ -54,7 +54,7 @@ from dataclasses import dataclass, field
 from functools import cached_property
 
 from typing import Any, Mapping, Optional, Callable, Dict, TYPE_CHECKING
-from immutables import Map
+from immutabledict import immutabledict
 
 from pytato.target import Target, BoundProgram
 from pytato.tags import ImplementationStrategy
@@ -137,7 +137,8 @@ class BoundPyOpenCLProgram(BoundProgram):
     """
     program: loopy.TranslationUnit
     _processed_bound_args_cache: Dict[pyopencl.Context,
-                                      Map[str, Any]] = field(default_factory=dict)
+                                      immutabledict[str, Any]] = \
+                                        field(default_factory=dict)
 
     def copy(self, *,
              program: Optional[loopy.TranslationUnit] = None,
@@ -169,7 +170,7 @@ class BoundPyOpenCLProgram(BoundProgram):
                                        queue: pyopencl.CommandQueue,
                                        allocator: Optional[Callable[
                                            [int], pyopencl.MemoryObject]],
-                                       ) -> Map[str, Any]:
+                                       ) -> immutabledict[str, Any]:
         import pyopencl.array as cla
 
         cache_key = queue.context
@@ -193,7 +194,7 @@ class BoundPyOpenCLProgram(BoundProgram):
                                     " numpy array, pyopencl array or scalar."
                                     f" Got {type(bnd_arg).__name__} for '{name}'.")
 
-            result = Map(proc_bnd_args)
+            result: immutabledict[str, Any] = immutabledict(proc_bnd_args)
             assert set(result.keys()) == set(self.bound_arguments.keys())
             self._processed_bound_args_cache[cache_key] = result
             return result

--- a/pytato/target/python/numpy_like.py
+++ b/pytato/target/python/numpy_like.py
@@ -38,7 +38,7 @@ from pytato.array import (Stack, Concatenate, IndexLambda, DataWrapper,
                           Reshape, Array, DictOfNamedArrays, IndexBase,
                           DataInterface, NormalizedSlice, ShapeComponent,
                           IndexExpr, ArrayOrScalar, NamedArray)
-from immutables import Map
+from immutabledict import immutabledict
 from pytato.scalar_expr import SCALAR_CLASSES
 from pytato.utils import are_shape_components_equal
 from pytato.raising import BinaryOpType, C99CallOp
@@ -601,4 +601,4 @@ def generate_numpy_like(expr: Union[Array, Mapping[str, Array], DictOfNamedArray
         program,
         function_name,
         expected_arguments=frozenset(cgen_mapper.arg_names),
-        bound_arguments=Map(cgen_mapper.bound_arguments))
+        bound_arguments=immutabledict(cgen_mapper.bound_arguments))

--- a/pytato/transform/__init__.py
+++ b/pytato/transform/__init__.py
@@ -354,7 +354,7 @@ class CopyMapper(CachedMapper[ArrayOrNames]):
                                  )
 
     def map_loopy_call(self, expr: LoopyCall) -> LoopyCall:
-        bindings: immutabledict[Any, Any] = immutabledict(
+        bindings: Mapping[Any, Any] = immutabledict(
                     {name: (self.rec(subexpr) if isinstance(subexpr, Array)
                            else subexpr)
                     for name, subexpr in sorted(expr.bindings.items())})
@@ -579,7 +579,7 @@ class CopyMapperWithExtraArgs(CachedMapper[ArrayOrNames]):
 
     def map_loopy_call(self, expr: LoopyCall,
                        *args: Any, **kwargs: Any) -> LoopyCall:
-        bindings: immutabledict[Any, Any] = immutabledict(
+        bindings: Mapping[Any, Any] = immutabledict(
                     {name: (self.rec(subexpr, *args, **kwargs)
                            if isinstance(subexpr, Array)
                            else subexpr)

--- a/pytato/transform/calls.py
+++ b/pytato/transform/calls.py
@@ -26,7 +26,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
-from immutables import Map
+from immutabledict import immutabledict
 from pytato.transform import (ArrayOrNames, CopyMapper)
 from pytato.array import (AbstractResultWithNamedArrays, Array,
                           DictOfNamedArrays, Placeholder)
@@ -44,7 +44,8 @@ class PlaceholderSubstitutor(CopyMapper):
         A mapping from the placeholder name to the array that it is to be
         substituted with.
     """
-    def __init__(self, substitutions: Map[str, Array]) -> None:
+
+    def __init__(self, substitutions: immutabledict[str, Array]) -> None:
         super().__init__()
         self.substitutions = substitutions
 

--- a/pytato/transform/calls.py
+++ b/pytato/transform/calls.py
@@ -26,7 +26,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
-from immutabledict import immutabledict
+from typing import Mapping
 from pytato.transform import (ArrayOrNames, CopyMapper)
 from pytato.array import (AbstractResultWithNamedArrays, Array,
                           DictOfNamedArrays, Placeholder)
@@ -45,7 +45,7 @@ class PlaceholderSubstitutor(CopyMapper):
         substituted with.
     """
 
-    def __init__(self, substitutions: immutabledict[str, Array]) -> None:
+    def __init__(self, substitutions: Mapping[str, Array]) -> None:
         super().__init__()
         self.substitutions = substitutions
 

--- a/pytato/transform/einsum_distributive_law.py
+++ b/pytato/transform/einsum_distributive_law.py
@@ -32,7 +32,7 @@ THE SOFTWARE.
 """
 
 
-from typing import Callable, Dict, Tuple, Optional, FrozenSet
+from typing import Callable, Dict, Tuple, Optional, FrozenSet, Mapping
 import attrs
 from pytato.transform import ArrayOrNames, Mapper, MappedT
 from pytato.array import (Array, AxesT, Einsum, IndexLambda,
@@ -74,10 +74,10 @@ class DoDistribute(EinsumDistributiveLawDescriptor):
 @attrs.frozen
 class _EinsumDistributiveLawMapperContext:
     access_descriptors: Tuple[Tuple[EinsumAxisDescriptor, ...], ...]
-    surrounding_args: immutabledict[int, Array]
-    redn_axis_to_redn_descr: immutabledict[EinsumReductionAxis,
+    surrounding_args: Mapping[int, Array]
+    redn_axis_to_redn_descr: Mapping[EinsumReductionAxis,
                                  ReductionDescriptor]
-    index_to_access_descr: immutabledict[str, EinsumAxisDescriptor]
+    index_to_access_descr: Mapping[str, EinsumAxisDescriptor]
     axes: AxesT = attrs.field(kw_only=True)
     tags: FrozenSet[Tag] = attrs.field(kw_only=True)
 

--- a/pytato/transform/einsum_distributive_law.py
+++ b/pytato/transform/einsum_distributive_law.py
@@ -41,7 +41,7 @@ from pytato.array import (Array, AxesT, Einsum, IndexLambda,
                           Stack, Concatenate, Roll, AxisPermutation,
                           IndexBase, Reshape, InputArgumentBase)
 from pytato.raising import HighLevelOp
-from immutables import Map
+from immutabledict import immutabledict
 from pytools.tag import Tag
 from pytato.utils import are_shapes_equal
 import numpy as np
@@ -74,10 +74,10 @@ class DoDistribute(EinsumDistributiveLawDescriptor):
 @attrs.frozen
 class _EinsumDistributiveLawMapperContext:
     access_descriptors: Tuple[Tuple[EinsumAxisDescriptor, ...], ...]
-    surrounding_args: Map[int, Array]
-    redn_axis_to_redn_descr: Map[EinsumReductionAxis,
+    surrounding_args: immutabledict[int, Array]
+    redn_axis_to_redn_descr: immutabledict[EinsumReductionAxis,
                                  ReductionDescriptor]
-    index_to_access_descr: Map[str, EinsumAxisDescriptor]
+    index_to_access_descr: immutabledict[str, EinsumAxisDescriptor]
     axes: AxesT = attrs.field(kw_only=True)
     tags: FrozenSet[Tag] = attrs.field(kw_only=True)
 
@@ -223,7 +223,7 @@ class EinsumDistributiveLawMapper(Mapper):
                 expr=expr.expr,
                 shape=expr.shape,
                 dtype=expr.dtype,
-                bindings=Map({name: self.rec(bnd, None)
+                bindings=immutabledict({name: self.rec(bnd, None)
                               for name, bnd in sorted(expr.bindings.items())}),
                 var_to_reduction_descr=expr.var_to_reduction_descr,
                 tags=expr.tags,
@@ -243,11 +243,11 @@ class EinsumDistributiveLawMapper(Mapper):
             else:
                 ctx = _EinsumDistributiveLawMapperContext(
                     expr.access_descriptors,
-                    Map({iarg: arg
+                    immutabledict({iarg: arg
                          for iarg, arg in enumerate(expr.args)
                          if iarg != distributive_law_descr.ioperand}),
-                    Map(expr.redn_axis_to_redn_descr),
-                    Map(expr.index_to_access_descr),
+                    immutabledict(expr.redn_axis_to_redn_descr),
+                    immutabledict(expr.index_to_access_descr),
                     tags=expr.tags,
                     axes=expr.axes,
                 )

--- a/pytato/transform/lower_to_index_lambda.py
+++ b/pytato/transform/lower_to_index_lambda.py
@@ -29,7 +29,7 @@ THE SOFTWARE.
 import pymbolic.primitives as prim
 
 from typing import List, Any, Dict, Tuple, TypeVar, TYPE_CHECKING
-from immutables import Map
+from immutabledict import immutabledict
 from pytools import UniqueNameGenerator
 from pytato.array import (Array, IndexLambda, Stack, Concatenate,
                           Einsum, Reshape, Roll, AxisPermutation,
@@ -96,7 +96,7 @@ class ToIndexLambdaMixin:
         return IndexLambda(expr=expr.expr,
                            shape=self._rec_shape(expr.shape),
                            dtype=expr.dtype,
-                           bindings=Map({name: self.rec(bnd)
+                           bindings=immutabledict({name: self.rec(bnd)
                                          for name, bnd
                                          in sorted(expr.bindings.items())}),
                            axes=expr.axes,
@@ -133,8 +133,8 @@ class ToIndexLambdaMixin:
                            shape=self._rec_shape(expr.shape),
                            dtype=expr.dtype,
                            axes=expr.axes,
-                           bindings=Map(bindings),
-                           var_to_reduction_descr=Map(),
+                           bindings=immutabledict(bindings),
+                           var_to_reduction_descr=immutabledict(),
                            tags=expr.tags)
 
     def map_concatenate(self, expr: Concatenate) -> IndexLambda:
@@ -180,9 +180,9 @@ class ToIndexLambdaMixin:
         return IndexLambda(expr=concat_expr,
                            shape=self._rec_shape(expr.shape),
                            dtype=expr.dtype,
-                           bindings=Map(bindings),
+                           bindings=immutabledict(bindings),
                            axes=expr.axes,
-                           var_to_reduction_descr=Map(),
+                           var_to_reduction_descr=immutabledict(),
                            tags=expr.tags)
 
     def map_einsum(self, expr: Einsum) -> IndexLambda:
@@ -249,9 +249,9 @@ class ToIndexLambdaMixin:
         return IndexLambda(expr=inner_expr,
                            shape=self._rec_shape(expr.shape),
                            dtype=expr.dtype,
-                           bindings=Map(bindings),
+                           bindings=immutabledict(bindings),
                            axes=expr.axes,
-                           var_to_reduction_descr=Map(var_to_redn_descr),
+                           var_to_reduction_descr=immutabledict(var_to_redn_descr),
                            tags=expr.tags)
 
     def map_roll(self, expr: Roll) -> IndexLambda:
@@ -275,10 +275,10 @@ class ToIndexLambdaMixin:
         return IndexLambda(expr=index_expr,
                            shape=self._rec_shape(expr.shape),
                            dtype=expr.dtype,
-                           bindings=Map({name: self.rec(bnd)
+                           bindings=immutabledict({name: self.rec(bnd)
                                      for name, bnd in bindings.items()}),
                            axes=expr.axes,
-                           var_to_reduction_descr=Map(),
+                           var_to_reduction_descr=immutabledict(),
                            tags=expr.tags)
 
     def map_contiguous_advanced_index(self,
@@ -338,11 +338,11 @@ class ToIndexLambdaMixin:
 
         return IndexLambda(expr=prim.Subscript(prim.Variable(in_ary),
                                                tuple(indices)),
-                           bindings=Map(bindings),
+                           bindings=immutabledict(bindings),
                            shape=self._rec_shape(expr.shape),
                            dtype=expr.dtype,
                            axes=expr.axes,
-                           var_to_reduction_descr=Map(),
+                           var_to_reduction_descr=immutabledict(),
                            tags=expr.tags,
                            )
 
@@ -400,11 +400,11 @@ class ToIndexLambdaMixin:
 
         return IndexLambda(expr=prim.Subscript(prim.Variable(in_ary),
                                                tuple(indices)),
-                           bindings=Map(bindings),
+                           bindings=immutabledict(bindings),
                            shape=self._rec_shape(expr.shape),
                            dtype=expr.dtype,
                            axes=expr.axes,
-                           var_to_reduction_descr=Map(),
+                           var_to_reduction_descr=immutabledict(),
                            tags=expr.tags,
                            )
 
@@ -433,11 +433,11 @@ class ToIndexLambdaMixin:
 
         return IndexLambda(expr=prim.Subscript(prim.Variable(in_ary),
                                                tuple(indices)),
-                           bindings=Map(bindings),
+                           bindings=immutabledict(bindings),
                            shape=self._rec_shape(expr.shape),
                            dtype=expr.dtype,
                            axes=expr.axes,
-                           var_to_reduction_descr=Map(),
+                           var_to_reduction_descr=immutabledict(),
                            tags=expr.tags,
                            )
 
@@ -447,9 +447,9 @@ class ToIndexLambdaMixin:
         return IndexLambda(expr=index_expr,
                            shape=self._rec_shape(expr.shape),
                            dtype=expr.dtype,
-                           bindings=Map({"_in0": self.rec(expr.array)}),
+                           bindings=immutabledict({"_in0": self.rec(expr.array)}),
                            axes=expr.axes,
-                           var_to_reduction_descr=Map(),
+                           var_to_reduction_descr=immutabledict(),
                            tags=expr.tags)
 
     def map_axis_permutation(self, expr: AxisPermutation) -> IndexLambda:
@@ -462,9 +462,9 @@ class ToIndexLambdaMixin:
         return IndexLambda(expr=index_expr,
                            shape=self._rec_shape(expr.shape),
                            dtype=expr.dtype,
-                           bindings=Map({"_in0": self.rec(expr.array)}),
+                           bindings=immutabledict({"_in0": self.rec(expr.array)}),
                            axes=expr.axes,
-                           var_to_reduction_descr=Map(),
+                           var_to_reduction_descr=immutabledict(),
                            tags=expr.tags)
 
 

--- a/pytato/transform/metadata.py
+++ b/pytato/transform/metadata.py
@@ -553,14 +553,14 @@ class AxesTagsEquationCollector(Mapper):
 
 def _get_propagation_graph_from_constraints(
         equations: List[Tuple[str, str]]) -> Mapping[str, FrozenSet[str]]:
-    import immutables
+    from immutabledict import immutabledict
     propagation_graph: Dict[str, Set[str]] = {}
     for lhs, rhs in equations:
         assert lhs != rhs
         propagation_graph.setdefault(lhs, set()).add(rhs)
         propagation_graph.setdefault(rhs, set()).add(lhs)
 
-    return immutables.Map({k: frozenset(v)
+    return immutabledict({k: frozenset(v)
                            for k, v in propagation_graph.items()})
 
 

--- a/pytato/utils.py
+++ b/pytato/utils.py
@@ -38,7 +38,7 @@ from pytato.scalar_expr import (ScalarExpression, IntegralScalarExpression,
                                 SCALAR_CLASSES, INT_CLASSES, BoolT, ScalarType)
 from pytools import UniqueNameGenerator
 from pytato.transform import Mapper
-from immutables import Map
+from immutabledict import immutabledict
 
 
 __doc__ = """
@@ -205,9 +205,9 @@ def broadcast_binary_op(a1: ArrayOrScalar, a2: ArrayOrScalar,
     return IndexLambda(expr=op(expr1, expr2),
                        shape=result_shape,
                        dtype=result_dtype,
-                       bindings=Map(bindings),
+                       bindings=immutabledict(bindings),
                        tags=_get_default_tags(),
-                       var_to_reduction_descr=Map(),
+                       var_to_reduction_descr=immutabledict(),
                        axes=_get_default_axes(len(result_shape)))
 
 

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     install_requires=[
         "loopy>=2020.2",
         "pytools>=2022.1.13",
-        "immutables",
+        "immutabledict",
         "attrs",
         "bidict",
         ],

--- a/test/test_pytato.py
+++ b/test/test_pytato.py
@@ -691,7 +691,7 @@ def test_basic_index_equality_traverses_underlying_arrays():
 
 def test_idx_lambda_to_hlo():
     from pytato.raising import index_lambda_to_high_level_op
-    from immutables import Map
+    from immutabledict import immutabledict
     from pytato.raising import (BinaryOp, BinaryOpType, FullOp, ReduceOp,
                                 C99CallOp, BroadcastOp)
 
@@ -734,11 +734,11 @@ def test_idx_lambda_to_hlo():
     assert (index_lambda_to_high_level_op(pt.sum(b, axis=1))
             == ReduceOp(SumReductionOperation(),
                         b,
-                        Map({1: "_r0"})))
+                        immutabledict({1: "_r0"})))
     assert (index_lambda_to_high_level_op(pt.prod(a))
             == ReduceOp(ProductReductionOperation(),
                         a,
-                        Map({0: "_r0",
+                        immutabledict({0: "_r0",
                              1: "_r1"})))
     assert index_lambda_to_high_level_op(pt.sinh(a)) == C99CallOp("sinh", (a,))
     assert index_lambda_to_high_level_op(pt.arctan2(b, a)) == C99CallOp("atan2",


### PR DESCRIPTION
Based on https://github.com/inducer/pytato/pull/457#issuecomment-1725926293, `immutabledict` has a consistent iteration order (like `dict`, i.e. insertion order), and is likely faster than `immutables.Map`, especially for actually immutable dicts (see also the graph [here](https://github.com/MagicStack/immutables#immutables)).