### PR TITLE
make MPI tags deterministic

### DIFF
--- a/pytato/distributed/__init__.py
+++ b/pytato/distributed/__init__.py
@@ -22,7 +22,8 @@ Internal stuff that is only here because the documentation tool wants it
 
 .. class:: CommTagType
 
-    A type representing a communication tag.
+    A type representing a communication tag. Communication tags must be
+    hashable and comparable.
 
 .. class:: ShapeType
 

--- a/pytato/distributed/__init__.py
+++ b/pytato/distributed/__init__.py
@@ -23,7 +23,7 @@ Internal stuff that is only here because the documentation tool wants it
 .. class:: CommTagType
 
     A type representing a communication tag. Communication tags must be
-    hashable and comparable.
+    hashable and totally ordered (and hence comparable).
 
 .. class:: ShapeType
 

--- a/pytato/distributed/tags.py
+++ b/pytato/distributed/tags.py
@@ -31,7 +31,7 @@ THE SOFTWARE.
 """
 
 
-from typing import TYPE_CHECKING, Tuple, FrozenSet, Any
+from typing import TYPE_CHECKING, Tuple, FrozenSet, Any, Optional
 
 from pytato.distributed.partition import DistributedGraphPartition
 
@@ -59,6 +59,10 @@ def number_distributed_tags(
 
         This is a potentially heavyweight MPI-collective operation on
         *mpi_communicator*.
+
+    .. note::
+
+        This function requires that symbolic tags are comparable.
     """
     tags = frozenset({
             recv.comm_tag
@@ -74,7 +78,7 @@ def number_distributed_tags(
 
     def set_union(
             set_a: FrozenSet[Any], set_b: FrozenSet[Any],
-            mpi_data_type: MPI.Datatype) -> FrozenSet[str]:
+            mpi_data_type: Optional[MPI.Datatype]) -> FrozenSet[Any]:
         assert mpi_data_type is None
         assert isinstance(set_a, frozenset)
         assert isinstance(set_b, frozenset)

--- a/pytato/distributed/tags.py
+++ b/pytato/distributed/tags.py
@@ -31,13 +31,16 @@ THE SOFTWARE.
 """
 
 
-from typing import TYPE_CHECKING, Tuple, FrozenSet, Any, Optional
+from typing import TYPE_CHECKING, Tuple, FrozenSet, Optional, TypeVar
 
 from pytato.distributed.partition import DistributedGraphPartition
 
 
 if TYPE_CHECKING:
     import mpi4py.MPI
+
+
+T = TypeVar("T")
 
 
 # {{{ construct tag numbering
@@ -77,8 +80,8 @@ def number_distributed_tags(
     from mpi4py import MPI
 
     def set_union(
-            set_a: FrozenSet[Any], set_b: FrozenSet[Any],
-            mpi_data_type: Optional[MPI.Datatype]) -> FrozenSet[Any]:
+            set_a: FrozenSet[T], set_b: FrozenSet[T],
+            mpi_data_type: Optional[MPI.Datatype]) -> FrozenSet[T]:
         assert mpi_data_type is None
         assert isinstance(set_a, frozenset)
         assert isinstance(set_b, frozenset)

--- a/pytato/distributed/tags.py
+++ b/pytato/distributed/tags.py
@@ -99,7 +99,7 @@ def number_distributed_tags(
         next_tag = base_tag
         assert isinstance(all_tags, frozenset)
 
-        for sym_tag in all_tags:
+        for sym_tag in sorted(all_tags):
             sym_tag_to_int_tag[sym_tag] = next_tag
             next_tag += 1
 


### PR DESCRIPTION
This requires tags to be sortable. The only other option I can see is to use some kind of ordered set type.