### PR TITLE
Partially restore recursive forwarding in mappers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,10 @@ jobs:
         -   name: "Main Script"
             run: |
                 curl -L -O https://gitlab.tiker.net/inducer/ci-support/raw/main/build-and-test-py-project-within-miniconda.sh
+                # pytest gets angry when 'import pytato.array' may come
+                # from both the project file and the venv. This matters
+                # because of doctest collection.
+                PROJECT_INSTALL_FLAGS="--editable"
                 . ./build-and-test-py-project-within-miniconda.sh
 
     examples:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,6 +4,10 @@ Python 3 POCL:
   - export PYOPENCL_TEST=portable:pthread
   - export EXTRA_INSTALL="pyopencl mpi4py jax[cpu]"
   - curl -L -O https://gitlab.tiker.net/inducer/ci-support/raw/main/build-and-test-py-project.sh
+  # pytest gets angry when 'import pytato.array' may come
+  # from both the project file and the venv. This matters
+  # because of doctest collection.
+  - 'PROJECT_INSTALL_FLAGS="--editable"'
   - ". ./build-and-test-py-project.sh"
   tags:
   - python3

--- a/pytato/transform/__init__.py
+++ b/pytato/transform/__init__.py
@@ -185,7 +185,9 @@ class Mapper:
         assert method is not None
         return method(expr, *args, **kwargs)
 
-    __call__ = rec
+    def __call__(self, expr: MappedT, *args: Any, **kwargs: Any) -> Any:
+        """Handle the mapping of *expr*."""
+        return self.rec(expr, *args, **kwargs)
 
 # }}}
 
@@ -244,7 +246,10 @@ class CopyMapper(CachedMapper[ArrayOrNames]):
             # type-ignore-reason: CachedMapper.rec's return type is imprecise
             return super().rec(expr)  # type: ignore[return-value]
 
-        __call__ = rec
+        # type-ignore-reason: specialized variant of super-class' rec method
+        def __call__(self,  # type: ignore[override]
+                     expr: CopyMapperResultT) -> CopyMapperResultT:
+            return self.rec(expr)
 
     def clone_for_callee(self: _SelfMapper) -> _SelfMapper:
         """
@@ -1233,7 +1238,9 @@ class CachedMapAndCopyMapper(CopyMapper):
         return result  # type: ignore[return-value]
 
     if TYPE_CHECKING:
-        __call__ = rec
+        # type-ignore-reason: Mapper.__call__ returns Any
+        def __call__(self, expr: MappedT) -> MappedT:  # type: ignore[override]
+            return self.rec(expr)
 
 # }}}
 


### PR DESCRIPTION
Partially undoes #446 by restoring `__call__`s that forward to `rec`. Using `__call__ = rec` is wrong, because it doesn't pick up versions of `rec` defined by subclasses.

Doesn't appear to have much impact on recursion depth post-#448.