### PR TITLE
number_distributed_tags: sort tags by repr

### DIFF
--- a/pytato/distributed/__init__.py
+++ b/pytato/distributed/__init__.py
@@ -23,7 +23,8 @@ Internal stuff that is only here because the documentation tool wants it
 .. class:: CommTagType
 
     A type representing a communication tag. Communication tags must be
-    hashable and totally ordered (and hence comparable).
+    hashable and have a textual representation via :func:`repr` that is
+    stable across Python invocations (to support sorting).
 
 .. class:: ShapeType
 

--- a/pytato/distributed/tags.py
+++ b/pytato/distributed/tags.py
@@ -106,7 +106,7 @@ def number_distributed_tags(
         next_tag = base_tag
         assert isinstance(all_tags, frozenset)
 
-        for sym_tag in sorted(all_tags):
+        for sym_tag in sorted(all_tags, key=lambda tag: repr(tag)):
             sym_tag_to_int_tag[sym_tag] = next_tag
             next_tag += 1
 

--- a/pytato/distributed/tags.py
+++ b/pytato/distributed/tags.py
@@ -65,7 +65,8 @@ def number_distributed_tags(
 
     .. note::
 
-        This function requires that symbolic tags are comparable.
+        This function requires that symbolic tags have a textual representation
+        that is stable across Python invocations.
     """
     tags = frozenset({
             recv.comm_tag


### PR DESCRIPTION
cc @MTcam

Should resolve issues like
```
TypeError: '<' not supported between instances of 'type' and 'type'
```

Followup to #462.