### PR TITLE
Fixes for functions

### DIFF
--- a/pytato/analysis/__init__.py
+++ b/pytato/analysis/__init__.py
@@ -431,6 +431,13 @@ class CallSiteCountMapper(CachedWalkMapper):
     def get_cache_key(self, expr: ArrayOrNames) -> int:
         return id(expr)
 
+    def update_from_callee_clone(
+            self,
+            function: FunctionDefinition,
+            callee_clone: CallSiteCountMapper) -> None:
+        super().update_from_callee_clone(function, callee_clone)
+        self.count += callee_clone.count
+
     @memoize_method
     def map_function_definition(self, /, expr: FunctionDefinition,
                                 *args: Any, **kwargs: Any) -> None:
@@ -440,8 +447,7 @@ class CallSiteCountMapper(CachedWalkMapper):
         new_mapper = self.clone_for_callee(expr)
         for subexpr in expr.returns.values():
             new_mapper(subexpr, *args, **kwargs)
-
-        self.count += new_mapper.count
+        self.update_from_callee_clone(expr, new_mapper)
 
         self.post_visit(expr, *args, **kwargs)
 

--- a/pytato/analysis/__init__.py
+++ b/pytato/analysis/__init__.py
@@ -432,13 +432,6 @@ class CallSiteCountMapper(CachedWalkMapper):
     def get_cache_key(self, expr: ArrayOrNames) -> int:
         return id(expr)
 
-    def update_from_callee_clone(
-            self,
-            function: FunctionDefinition,
-            callee_clone: CallSiteCountMapper) -> None:
-        super().update_from_callee_clone(function, callee_clone)
-        self.count += callee_clone.count
-
     @memoize_method
     def map_function_definition(self, /, expr: FunctionDefinition,
                                 *args: Any, **kwargs: Any) -> None:
@@ -448,7 +441,7 @@ class CallSiteCountMapper(CachedWalkMapper):
         new_mapper = self.clone_for_callee(expr)
         for subexpr in expr.returns.values():
             new_mapper(subexpr, *args, **kwargs)
-        self.update_from_callee_clone(expr, new_mapper)
+        self.count += new_mapper.count
 
         self.post_visit(expr, *args, **kwargs)
 

--- a/pytato/analysis/__init__.py
+++ b/pytato/analysis/__init__.py
@@ -368,8 +368,9 @@ class DirectPredecessorsGetter(Mapper):
         return frozenset([expr.passthrough_data])
 
     def map_named_call_result(self, expr: NamedCallResult) -> FrozenSet[Array]:
-        # Not sure if this should descend into the function definition or not?
-        return frozenset(expr.call.bindings.values())
+        raise NotImplementedError(
+            "DirectPredecessorsGetter does not yet support expressions containing "
+            "functions.")
 
 
 # }}}

--- a/pytato/codegen.py
+++ b/pytato/codegen.py
@@ -118,12 +118,6 @@ class CodeGenPreprocessor(ToIndexLambdaMixin, CopyMapper):  # type: ignore[misc]
         # Would need to sync bound_arguments/var_name_gen from clones
         raise NotImplementedError("CodeGenPreprocessor does not support functions.")
 
-    def update_from_callee_clone(
-            self: _SelfMapper, function: FunctionDefinition,
-            callee_clone: _SelfMapper) -> None:
-        # Would need to sync bound_arguments/var_name_gen from clones
-        raise NotImplementedError("CodeGenPreprocessor does not support functions.")
-
     def map_size_param(self, expr: SizeParam) -> Array:
         name = expr.name
         assert name is not None

--- a/pytato/codegen.py
+++ b/pytato/codegen.py
@@ -118,6 +118,12 @@ class CodeGenPreprocessor(ToIndexLambdaMixin, CopyMapper):  # type: ignore[misc]
         # Would need to sync bound_arguments/var_name_gen from clones
         raise NotImplementedError("CodeGenPreprocessor does not support functions.")
 
+    def update_from_callee_clone(
+            self: _SelfMapper, function: FunctionDefinition,
+            callee_clone: _SelfMapper) -> None:
+        # Would need to sync bound_arguments/var_name_gen from clones
+        raise NotImplementedError("CodeGenPreprocessor does not support functions.")
+
     def map_size_param(self, expr: SizeParam) -> Array:
         name = expr.name
         assert name is not None

--- a/pytato/codegen.py
+++ b/pytato/codegen.py
@@ -30,12 +30,12 @@ from pytato.array import (Array, DictOfNamedArrays, DataWrapper, Placeholder,
                           DataInterface, SizeParam, InputArgumentBase,
                           make_dict_of_named_arrays)
 
-from pytato.function import FunctionDefinition
+from pytato.function import NamedCallResult
 from pytato.transform.lower_to_index_lambda import ToIndexLambdaMixin
 
 from pytato.scalar_expr import IntegralScalarExpression
 from pytato.transform import (CopyMapper, CachedWalkMapper,
-                              SubsetDependencyMapper, ArrayOrNames, _SelfMapper)
+                              SubsetDependencyMapper, ArrayOrNames)
 from pytato.target import Target
 from pytato.loopy import LoopyCall
 from pytools import UniqueNameGenerator
@@ -112,11 +112,6 @@ class CodeGenPreprocessor(ToIndexLambdaMixin, CopyMapper):  # type: ignore[misc]
         self.var_name_gen: UniqueNameGenerator = UniqueNameGenerator()
         self.target = target
         self.kernels_seen: Dict[str, lp.LoopKernel] = kernels_seen or {}
-
-    def clone_for_callee(
-            self: _SelfMapper, function: FunctionDefinition) -> CodeGenPreprocessor:
-        # Would need to sync bound_arguments/var_name_gen from clones
-        raise NotImplementedError("CodeGenPreprocessor does not support functions.")
 
     def map_size_param(self, expr: SizeParam) -> Array:
         name = expr.name
@@ -198,6 +193,9 @@ class CodeGenPreprocessor(ToIndexLambdaMixin, CopyMapper):  # type: ignore[misc]
                 dtype=expr.dtype,
                 axes=expr.axes,
                 tags=expr.tags)
+
+    def map_named_call_result(self, expr: NamedCallResult) -> Array:
+        raise NotImplementedError("CodeGenPreprocessor does not support functions.")
 
 # }}}
 

--- a/pytato/codegen.py
+++ b/pytato/codegen.py
@@ -30,11 +30,12 @@ from pytato.array import (Array, DictOfNamedArrays, DataWrapper, Placeholder,
                           DataInterface, SizeParam, InputArgumentBase,
                           make_dict_of_named_arrays)
 
+from pytato.function import FunctionDefinition
 from pytato.transform.lower_to_index_lambda import ToIndexLambdaMixin
 
 from pytato.scalar_expr import IntegralScalarExpression
 from pytato.transform import (CopyMapper, CachedWalkMapper,
-                              SubsetDependencyMapper, ArrayOrNames)
+                              SubsetDependencyMapper, ArrayOrNames, _SelfMapper)
 from pytato.target import Target
 from pytato.loopy import LoopyCall
 from pytools import UniqueNameGenerator
@@ -112,8 +113,10 @@ class CodeGenPreprocessor(ToIndexLambdaMixin, CopyMapper):  # type: ignore[misc]
         self.target = target
         self.kernels_seen: Dict[str, lp.LoopKernel] = kernels_seen or {}
 
-    def clone_for_callee(self) -> CodeGenPreprocessor:
-        return CodeGenPreprocessor(self.target, self.kernels_seen)
+    def clone_for_callee(
+            self: _SelfMapper, function: FunctionDefinition) -> CodeGenPreprocessor:
+        # Would need to sync bound_arguments/var_name_gen from clones
+        raise NotImplementedError("CodeGenPreprocessor does not support functions.")
 
     def map_size_param(self, expr: SizeParam) -> Array:
         name = expr.name

--- a/pytato/distributed/partition.py
+++ b/pytato/distributed/partition.py
@@ -272,6 +272,14 @@ class DistributedGraphPartition:
 
 # {{{ _DistributedInputReplacer
 
+class _PlaceholderGenerator:
+    """Generates a unique placeholder given an input name/array."""
+    @memoize_method
+    def __call__(self, name: str, expr: Array) -> Placeholder:
+        return make_placeholder(
+            name, expr.shape, expr.dtype, expr.tags, expr.axes)
+
+
 class _DistributedInputReplacer(CopyMapper):
     """Replaces part inputs with :class:`~pytato.array.Placeholder`
     instances for their assigned names. Also gathers names for
@@ -282,6 +290,7 @@ class _DistributedInputReplacer(CopyMapper):
                  recvd_ary_to_name: Mapping[Array, str],
                  sptpo_ary_to_name: Mapping[Array, str],
                  name_to_output: Mapping[str, Array],
+                 placeholder_generator: Optional[_PlaceholderGenerator] = None
                  ) -> None:
         super().__init__()
 
@@ -290,15 +299,23 @@ class _DistributedInputReplacer(CopyMapper):
         self.name_to_output = name_to_output
         self.output_arrays = frozenset(name_to_output.values())
 
+        if placeholder_generator is not None:
+            self._placeholder_generator = placeholder_generator
+        else:
+            self._placeholder_generator = _PlaceholderGenerator()
+
         self.user_input_names: Set[str] = set()
-        self.partition_input_name_to_placeholder: Dict[str, Placeholder] = {}
+        self.partition_input_names: Set[str] = set()
 
     def clone_for_callee(
             self, function: FunctionDefinition) -> _DistributedInputReplacer:
         return type(self)(
             self.recvd_ary_to_name,
             self.sptpo_ary_to_name,
-            self.name_to_output)
+            self.name_to_output,
+            # Clones must use the same generator in order to avoid potentially
+            # duplicating placeholders
+            self._placeholder_generator)
 
     def update_from_callee_clone(
             self,
@@ -308,10 +325,7 @@ class _DistributedInputReplacer(CopyMapper):
 
         self.user_input_names |= (
             callee_clone.user_input_names - function.parameters)
-        # Seems questionable? If name is used both inside and outside function,
-        # could end up with duplicate placeholders?
-        self.partition_input_name_to_placeholder.update(
-            callee_clone.partition_input_name_to_placeholder)
+        self.partition_input_names |= callee_clone.partition_input_names
 
     def map_placeholder(self, expr: Placeholder) -> Placeholder:
         self.user_input_names.add(expr.name)
@@ -363,12 +377,8 @@ class _DistributedInputReplacer(CopyMapper):
         return cast(ArrayOrNames, super().rec(expr))
 
     def _get_placeholder_for(self, name: str, expr: Array) -> Placeholder:
-        placeholder = self.partition_input_name_to_placeholder.get(name)
-        if placeholder is None:
-            placeholder = make_placeholder(
-                    name, expr.shape, expr.dtype, expr.tags,
-                    expr.axes)
-            self.partition_input_name_to_placeholder[name] = placeholder
+        placeholder = self._placeholder_generator(name, expr)
+        self.partition_input_names.add(name)
         return placeholder
 
 # }}}
@@ -418,8 +428,7 @@ def _make_distributed_partition(
                 pid=part_id,
                 needed_pids=frozenset({part_id - 1} if part_id else {}),
                 user_input_names=frozenset(comm_replacer.user_input_names),
-                partition_input_names=frozenset(
-                    comm_replacer.partition_input_name_to_placeholder.keys()),
+                partition_input_names=frozenset(comm_replacer.partition_input_names),
                 output_names=frozenset(name_to_ouput.keys()),
                 name_to_recv_node=immutabledict({
                     recvd_ary_to_name[local_recv_id_to_recv_node[recv_id]]:

--- a/pytato/distributed/partition.py
+++ b/pytato/distributed/partition.py
@@ -508,12 +508,10 @@ class _LocalSendRecvDepGatherer(
 
         return frozenset({recv_id})
 
-    @memoize_method
-    def map_function_definition(
-            self, expr: FunctionDefinition
-            ) -> FrozenSet[CommunicationOpIdentifier]:
-        # Assume no communication in the function body
-        return frozenset()
+    def map_named_call_result(
+            self, expr: NamedCallResult) -> FrozenSet[CommunicationOpIdentifier]:
+        raise NotImplementedError(
+            "LocalSendRecvDepGatherer does not support functions.")
 
 # }}}
 

--- a/pytato/function.py
+++ b/pytato/function.py
@@ -173,7 +173,7 @@ class FunctionDefinition(Taggable):
 
         if self.parameters != frozenset(kwargs):
             missing_params = self.parameters - frozenset(kwargs)
-            extra_params = self.parameters - frozenset(kwargs)
+            extra_params = frozenset(kwargs) - self.parameters
 
             raise TypeError(
                     "Incorrect arguments."

--- a/pytato/function.py
+++ b/pytato/function.py
@@ -134,16 +134,22 @@ class FunctionDefinition(Taggable):
 
         mapper = InputGatherer()
 
-        all_placeholder_args: FrozenSet[Placeholder] = frozenset()
+        all_placeholders: FrozenSet[Placeholder] = frozenset()
         for ary in self.returns.values():
-            new_placeholder_args = frozenset({
+            new_placeholders = frozenset({
                 arg for arg in mapper(ary)
-                if (
-                    isinstance(arg, Placeholder)
-                    and arg.name in self.parameters)})
-            all_placeholder_args |= new_placeholder_args
+                if isinstance(arg, Placeholder)})
+            all_placeholders |= new_placeholders
 
-        return immutabledict({arg.name: arg for arg in all_placeholder_args})
+        # FIXME: Need a way to check for *any* captured arrays, not just placeholders
+        if __debug__:
+            pl_names = frozenset(arg.name for arg in all_placeholders)
+            extra_pl_names = pl_names - self.parameters
+            assert not extra_pl_names, \
+                f"Found non-argument placeholder '{next(iter(extra_pl_names))}' " \
+                "in function definition."
+
+        return immutabledict({arg.name: arg for arg in all_placeholders})
 
     def get_placeholder(self, name: str) -> Placeholder:
         """

--- a/pytato/stringifier.py
+++ b/pytato/stringifier.py
@@ -169,8 +169,7 @@ class Reprifier(Mapper):
 
         return (f"{type(expr).__name__}("
                 + ", ".join(f"{field.name}={_get_field_val(field.name)}"
-                    # type-ignore-reason: https://github.com/python/mypy/issues/16254
-                        for field in attrs.fields(type(expr)))  # type: ignore[misc]
+                        for field in attrs.fields(type(expr)))
                 + ")")
 
     def map_call(self, expr: Call, depth: int) -> str:

--- a/pytato/stringifier.py
+++ b/pytato/stringifier.py
@@ -26,10 +26,13 @@ THE SOFTWARE.
 
 import numpy as np
 
+from pytools import memoize_method
+
 from typing import Any, Dict, Tuple, cast
 from pytato.transform import Mapper
 from pytato.array import (Array, DataWrapper, DictOfNamedArrays, Axis,
                           IndexLambda, ReductionDescriptor)
+from pytato.function import FunctionDefinition, Call
 from pytato.loopy import LoopyCall
 from immutabledict import immutabledict
 import attrs
@@ -151,6 +154,39 @@ class Reprifier(Mapper):
         return (f"{type(expr).__name__}("
                 + ", ".join(f"{field.name}={_get_field_val(field.name)}"
                         for field in attrs.fields(type(expr)))
+                + ")")
+
+    @memoize_method
+    def map_function_definition(self, expr: FunctionDefinition, depth: int) -> str:
+        if depth > self.truncation_depth:
+            return self.truncation_string
+
+        def _get_field_val(field: str) -> str:
+            if field == "returns":
+                return self.rec(getattr(expr, field), depth+1)
+            else:
+                return repr(getattr(expr, field))
+
+        return (f"{type(expr).__name__}("
+                + ", ".join(f"{field.name}={_get_field_val(field.name)}"
+                    # type-ignore-reason: https://github.com/python/mypy/issues/16254
+                        for field in attrs.fields(type(expr)))  # type: ignore[misc]
+                + ")")
+
+    def map_call(self, expr: Call, depth: int) -> str:
+        if depth > self.truncation_depth:
+            return self.truncation_string
+
+        def _get_field_val(field: str) -> str:
+            if field == "function":
+                return self.map_function_definition(expr.function, depth+1)
+            else:
+                return self.rec(getattr(expr, field), depth+1)
+
+        return (f"{type(expr).__name__}("
+                + ", ".join(f"{field}={_get_field_val(field)}"
+                            for field in ["function",
+                                          "bindings"])
                 + ")")
 
     def map_loopy_call(self, expr: LoopyCall, depth: int) -> str:

--- a/pytato/target/loopy/codegen.py
+++ b/pytato/target/loopy/codegen.py
@@ -592,13 +592,13 @@ class CodeGenMapper(Mapper):
         raise NotImplementedError("LoopyTarget does not support outlined calls"
                                   " (yet). As a fallback, the call"
                                   " could be inlined using"
-                                  " pt.mark_all_calls_to_be_inlined.")
+                                  " pt.tag_all_calls_to_be_inlined.")
 
     def map_call(self, expr: Call, state: CodeGenState) -> None:
         raise NotImplementedError("LoopyTarget does not support outlined calls"
                                   " (yet). As a fallback, the call"
                                   " could be inlined using"
-                                  " pt.mark_all_calls_to_be_inlined.")
+                                  " pt.tag_all_calls_to_be_inlined.")
 
 # }}}
 

--- a/pytato/target/loopy/codegen.py
+++ b/pytato/target/loopy/codegen.py
@@ -352,6 +352,7 @@ class CodeGenMapper(Mapper):
     def __init__(self,
                  array_tag_t_to_not_propagate: FrozenSet[Type[Tag]],
                  axis_tag_t_to_not_propagate: FrozenSet[Type[Tag]]) -> None:
+        super().__init__()
         self.exprgen_mapper = InlinedExpressionGenMapper(axis_tag_t_to_not_propagate)
         self.array_tag_t_to_not_propagate = array_tag_t_to_not_propagate
         self.axis_tag_t_to_not_propagate = axis_tag_t_to_not_propagate

--- a/pytato/transform/__init__.py
+++ b/pytato/transform/__init__.py
@@ -233,7 +233,6 @@ class CopyMapper(CachedMapper[ArrayOrNames]):
     in subclasses to permit term rewriting on an expression graph.
 
     .. automethod:: clone_for_callee
-    .. automethod:: update_from_callee_clone
 
     .. note::
 
@@ -253,15 +252,6 @@ class CopyMapper(CachedMapper[ArrayOrNames]):
         :class:`pytato.function.FunctionDefinition`.
         """
         return type(self)()
-
-    def update_from_callee_clone(
-            self: _SelfMapper, function: FunctionDefinition,
-            callee_clone: _SelfMapper) -> None:
-        """
-        Called to update any data stored in *self* after using a cloned mapper
-        to traverse a :class:`pytato.function.FunctionDefinition`.
-        """
-        pass
 
     def rec_idx_or_size_tuple(self, situp: Tuple[IndexOrShapeExpr, ...]
                               ) -> Tuple[IndexOrShapeExpr, ...]:
@@ -415,7 +405,6 @@ class CopyMapper(CachedMapper[ArrayOrNames]):
         new_mapper = self.clone_for_callee(expr)
         new_returns = {name: new_mapper(ret)
                        for name, ret in expr.returns.items()}
-        self.update_from_callee_clone(expr, new_mapper)
         return attrs.evolve(expr, returns=immutabledict(new_returns))
 
     def map_call(self, expr: Call) -> AbstractResultWithNamedArrays:
@@ -969,11 +958,6 @@ class WalkMapper(Mapper):
             self: _SelfMapper, function: FunctionDefinition) -> _SelfMapper:
         return type(self)()
 
-    def update_from_callee_clone(
-            self: _SelfMapper, function: FunctionDefinition,
-            callee_clone: _SelfMapper) -> None:
-        pass
-
     def visit(self, expr: Any, *args: Any, **kwargs: Any) -> bool:
         """
         If this method returns *True*, *expr* is traversed during the walk.
@@ -1134,7 +1118,6 @@ class WalkMapper(Mapper):
         new_mapper = self.clone_for_callee(expr)
         for subexpr in expr.returns.values():
             new_mapper(subexpr, *args, **kwargs)
-        self.update_from_callee_clone(expr, new_mapper)
 
         self.post_visit(expr, *args, **kwargs)
 

--- a/pytato/transform/__init__.py
+++ b/pytato/transform/__init__.py
@@ -201,6 +201,7 @@ class CachedMapper(Mapper, Generic[CachedMapperT]):
     """
 
     def __init__(self) -> None:
+        super().__init__()
         self._cache: Dict[Hashable, CachedMapperT] = {}
 
     def get_cache_key(self, expr: ArrayOrNames) -> Hashable:
@@ -430,6 +431,7 @@ class CopyMapperWithExtraArgs(CachedMapper[ArrayOrNames]):
     arguments to keep the cost of its each call frame low.
     """
     def __init__(self) -> None:
+        super().__init__()
         # type-ignored as '._cache' attribute is not coherent with the base
         # class
         self._cache: Dict[Tuple[ArrayOrNames,
@@ -657,6 +659,7 @@ class CombineMapper(Mapper, Generic[CombineT]):
     .. automethod:: combine
     """
     def __init__(self) -> None:
+        super().__init__()
         self.cache: Dict[ArrayOrNames, CombineT] = {}
 
     def rec_idx_or_size_tuple(self, situp: Tuple[IndexOrShapeExpr, ...]
@@ -1149,6 +1152,7 @@ class CachedWalkMapper(WalkMapper):
     """
 
     def __init__(self) -> None:
+        super().__init__()
         self._visited_nodes: Set[Any] = set()
 
     def get_cache_key(self, expr: ArrayOrNames, *args: Any, **kwargs: Any) -> Any:

--- a/pytato/transform/__init__.py
+++ b/pytato/transform/__init__.py
@@ -913,9 +913,13 @@ class InputGatherer(CombineMapper[FrozenSet[InputArgumentBase]]):
                                                  for ret in expr.returns.values()])
         result: Set[InputArgumentBase] = set()
         for inp in all_callee_inputs:
-            if isinstance(inp, Placeholder) and inp.name in expr.parameters:
-                # drop, reference to argument
-                pass
+            if isinstance(inp, Placeholder):
+                if inp.name in expr.parameters:
+                    # drop, reference to argument
+                    pass
+                else:
+                    raise ValueError("function definition refers to non-argument "
+                                     f"placeholder named '{inp.name}'")
             else:
                 result.add(inp)
 

--- a/pytato/transform/calls.py
+++ b/pytato/transform/calls.py
@@ -74,9 +74,12 @@ class Inliner(CopyMapper):
             return new_expr
 
     def map_named_call_result(self, expr: NamedCallResult) -> Array:
-        new_call = self.rec(expr._container)
-        assert isinstance(new_call, AbstractResultWithNamedArrays)
-        return new_call[expr.name].expr
+        new_call_or_inlined_expr = self.rec(expr._container)
+        assert isinstance(new_call_or_inlined_expr, AbstractResultWithNamedArrays)
+        if isinstance(new_call_or_inlined_expr, Call):
+            return new_call_or_inlined_expr[expr.name]
+        else:
+            return new_call_or_inlined_expr[expr.name].expr
 
 
 class InlineMarker(CopyMapper):

--- a/pytato/transform/calls.py
+++ b/pytato/transform/calls.py
@@ -50,10 +50,7 @@ class PlaceholderSubstitutor(CopyMapper):
         self.substitutions = substitutions
 
     def map_placeholder(self, expr: Placeholder) -> Array:
-        if expr.name in self.substitutions:
-            return self.substitutions[expr.name]
-        else:
-            return super().map_placeholder(expr)
+        return self.substitutions[expr.name]
 
 
 class Inliner(CopyMapper):

--- a/pytato/transform/metadata.py
+++ b/pytato/transform/metadata.py
@@ -48,6 +48,7 @@ from pytato.array import (InputArgumentBase, Stack, Concatenate, IndexLambda,
                           DictOfNamedArrays, NamedArray,
                           AbstractResultWithNamedArrays, ArrayOrScalar,
                           EinsumReductionAxis)
+from pytato.function import NamedCallResult
 from pytato.distributed.nodes import DistributedRecv, DistributedSendRefHolder
 from pytato.utils import are_shape_components_equal, are_shapes_equal
 from pytato.raising import (index_lambda_to_high_level_op,
@@ -545,6 +546,11 @@ class AxesTagsEquationCollector(Mapper):
         more equations are deduced.
         """
 
+    def map_named_call_result(self, expr: NamedCallResult) -> Array:
+        raise NotImplementedError(
+            "AxesTagsEquationCollector does not currently support expressions "
+            "containing functions.")
+
     # }}}
 
 # }}}
@@ -641,6 +647,11 @@ class AxisTagAttacher(CopyMapper):
 
                 self._cache[key] = expr_copy
                 return expr_copy
+
+    def map_named_call_result(self, expr: NamedCallResult) -> Array:
+        raise NotImplementedError(
+            "AxisTagAttacher does not currently support expressions containing "
+            "functions.")
 
     # type-ignore reason: overrides the type of Mapper.__call__
     def __call__(self, expr: ArrayOrNames) -> ArrayOrNames:  # type: ignore[override]

--- a/pytato/utils.py
+++ b/pytato/utils.py
@@ -218,6 +218,7 @@ class ShapeExpressionMapper(Mapper):
     Mapper that takes a shape component and returns it as a scalar expression.
     """
     def __init__(self, var_name_gen: UniqueNameGenerator):
+        super().__init__()
         self.cache: Dict[Array, ScalarExpression] = {}
         self.var_name_gen = var_name_gen
         self.bindings: Dict[str, SizeParam] = {}
@@ -320,6 +321,7 @@ class ShapeToISLExpressionMapper(Mapper):
     Mapper that takes a shape component and returns it as :class:`isl.Aff`.
     """
     def __init__(self, space: isl.Space):
+        super().__init__()
         self.cache: Dict[Array, isl.Aff] = {}
         self.space = space
 


### PR DESCRIPTION
Adds fixes needed to make outlining of inviscid/viscous fluxes work in mirgecom.

Note: Only works if functions are inlined at the beginning of `_dag_to_compiled_func` in grudge's lazy function caller, due to interactions with axis tagging (see #470).