### PR TITLE
run all examples, fix demo_distributed_node_duplication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
                 . ci-support-v0
                 build_py_project_in_conda_env
                 pip install pytest  # for advection.py
-                run_examples
+                run_examples --no-require-main
 
     docs:
         name: Documentation

--- a/examples/demo_distributed_node_duplication.py
+++ b/examples/demo_distributed_node_duplication.py
@@ -1,14 +1,19 @@
 """
 An example to demonstrate the behavior of
-:func:`pytato.find_distrbuted_partition`. One of the key characteristic of the
-partitioning routine is to recompute expressions that appear in the multiple
+:func:`pytato.find_distributed_partition`. One of the key characteristics of the
+partitioning routine is to recompute expressions that appear in multiple
 partitions but are not materialized.
 """
 import pytato as pt
 import numpy as np
+from mpi4py import MPI
+
+comm = MPI.COMM_WORLD
 
 size = 2
 rank = 0
+
+pt.enable_traceback_tag()
 
 x1 = pt.make_placeholder("x1", shape=(10, 4), dtype=np.float64)
 x2 = pt.make_placeholder("x2", shape=(10, 4), dtype=np.float64)
@@ -30,7 +35,7 @@ recv = pt.staple_distributed_send(tmp4, dest_rank=(rank-1) % size, comm_tag=10,
 out = tmp2 + recv
 result = pt.make_dict_of_named_arrays({"out": out})
 
-partitions = pt.find_distributed_partition(result)
+partitions = pt.find_distributed_partition(comm, result)
 
 # Visualize *partitions* to see that each of the two partitions contains a node
 # named 'tmp2'.

--- a/examples/demo_distributed_node_duplication.py
+++ b/examples/demo_distributed_node_duplication.py
@@ -13,8 +13,6 @@ comm = MPI.COMM_WORLD
 size = 2
 rank = 0
 
-pt.enable_traceback_tag()
-
 x1 = pt.make_placeholder("x1", shape=(10, 4), dtype=np.float64)
 x2 = pt.make_placeholder("x2", shape=(10, 4), dtype=np.float64)
 x3 = pt.make_placeholder("x3", shape=(10, 4), dtype=np.float64)


### PR DESCRIPTION
From #284.

The `comm` does not make much sense here, but the example and the output regarding `tmp2` seem to work as expected.

*Please squash*