### PR TITLE
Get precise traceback of array creation

### DIFF
--- a/pytato/array.py
+++ b/pytato/array.py
@@ -558,7 +558,7 @@ class Array(Taggable):
         # }}}
 
         tags = _get_default_tags()
-        non_equality_tags = frozenset({_get_created_at_tag(stacklevel=2)})
+        non_equality_tags = frozenset({_get_created_at_tag()})
 
         import pytato.utils as utils
         if reverse:
@@ -590,7 +590,7 @@ class Array(Taggable):
                 bindings=bindings,
                 tags=_get_default_tags(),
                 axes=_get_default_axes(self.ndim),
-                non_equality_tags=frozenset({_get_created_at_tag(stacklevel=2)}),
+                non_equality_tags=frozenset({_get_created_at_tag()}),
                 var_to_reduction_descr=immutabledict())
 
     __mul__ = partialmethod(_binary_op, operator.mul)

--- a/pytato/cmath.py
+++ b/pytato/cmath.py
@@ -115,7 +115,7 @@ def _apply_elem_wise_func(inputs: Tuple[ArrayOrScalar, ...],
                   tuple(sym_args)),
         shape=shape, dtype=ret_dtype, bindings=immutabledict(bindings),
         tags=_get_default_tags(),
-        non_equality_tags=frozenset({_get_created_at_tag()}),
+        non_equality_tags=frozenset({_get_created_at_tag(stacklevel=2)}),
         axes=_get_default_axes(len(shape)),
         var_to_reduction_descr=immutabledict(),
     )


### PR DESCRIPTION
Removes the

```python
pytato/array.py:2049, in concatenate(): non_equality_tags=frozenset({_get_created_at_tag()}),
pytato/array.py:1887, in _get_created_at_tag(): for s in traceback.extract_stack()))})
```

and any other internal pytato stuff from the end of the stack trace stored in the `CreatedAt` tag.