### PR TITLE
fix some warnings in tests

### DIFF
--- a/pytato/array.py
+++ b/pytato/array.py
@@ -2230,7 +2230,10 @@ def arange(*args: Any, **kwargs: Any) -> Array:
     step = dtype.type(inf.step)
     stop = dtype.type(inf.stop)
 
-    size = max(0, int(np.ceil((np.real(stop)-np.real(start))/np.real(step))))
+    from math import ceil
+    # np.real() suppresses "ComplexWarning: Casting complex values to real
+    # discards the imaginary part":
+    size = max(0, int(ceil((np.real(stop)-np.real(start))/np.real(step))))
 
     from pymbolic.primitives import Variable
     return IndexLambda(expr=start + Variable("_0") * step,

--- a/pytato/array.py
+++ b/pytato/array.py
@@ -2230,8 +2230,7 @@ def arange(*args: Any, **kwargs: Any) -> Array:
     step = dtype.type(inf.step)
     stop = dtype.type(inf.stop)
 
-    from math import ceil
-    size = max(0, int(ceil((stop-start)/step)))
+    size = max(0, int(np.ceil((np.real(stop)-np.real(start))/np.real(step))))
 
     from pymbolic.primitives import Variable
     return IndexLambda(expr=start + Variable("_0") * step,

--- a/test/test_codegen.py
+++ b/test/test_codegen.py
@@ -1038,6 +1038,8 @@ def test_arange(ctx_factory):
     ctx = ctx_factory()
     cq = cl.CommandQueue(ctx)
 
+    # {{{ Integer
+
     from numpy.random import default_rng
     rng = default_rng(seed=0)
     for _ in range(30):
@@ -1052,6 +1054,43 @@ def test_arange(ctx_factory):
         _, (pt_res,) = pt.generate_loopy(pt_res_sym)(cq)
 
         assert np.array_equal(pt_res, np_res)
+
+    # }}}
+
+    # {{{ Real
+
+    # generates '[0. ... 4.]':
+    np_res = np.arange(5, dtype=np.float64)
+    pt_res_sym = pt.arange(5, dtype=np.float64)
+
+    _, (pt_res,) = pt.generate_loopy(pt_res_sym)(cq)
+    print(np_res, pt_res)
+
+    assert np.array_equal(pt_res, np_res)
+
+    # }}}
+
+    # {{{ Complex
+
+    # generates '[]':
+    np_res = np.arange(5j, dtype=np.complex128)
+    pt_res_sym = pt.arange(5j, dtype=np.complex128)
+
+    _, (pt_res,) = pt.generate_loopy(pt_res_sym)(cq)
+    print(np_res, pt_res)
+
+    assert np.array_equal(pt_res, np_res)
+
+    # generates '[0.+0.j ... 4.+0.j]':
+    np_res = np.arange(5, dtype=np.complex128)
+    pt_res_sym = pt.arange(5, dtype=np.complex128)
+
+    _, (pt_res,) = pt.generate_loopy(pt_res_sym)(cq)
+    print(np_res, pt_res)
+
+    assert np.array_equal(pt_res, np_res)
+
+    # }}}
 
 
 @pytest.mark.parametrize("which,num_args", ([("maximum", 2),


### PR DESCRIPTION
This reduces the number of warnings from ~7800 to ~380.