### PR TITLE
Change Dict -> Mapping in CopyMapperWithExtraArgs

### DIFF
--- a/pytato/transform/__init__.py
+++ b/pytato/transform/__init__.py
@@ -474,9 +474,9 @@ class CopyMapperWithExtraArgs(CachedMapper[ArrayOrNames]):
 
     def map_index_lambda(self, expr: IndexLambda,
                          *args: Any, **kwargs: Any) -> Array:
-        bindings: Dict[str, Array] = {
-                name: self.rec(subexpr, *args, **kwargs)
-                for name, subexpr in sorted(expr.bindings.items())}
+        bindings: Mapping[str, Array] = immutabledict({
+                name: self.rec(subexpr)
+                for name, subexpr in sorted(expr.bindings.items())})
         return IndexLambda(expr=expr.expr,
                            shape=self.rec_idx_or_size_tuple(expr.shape,
                                                             *args, **kwargs),


### PR DESCRIPTION
`bindings` is expected to *not* be a Dict in `IndexLambda`. This change mimics the construction of bindings in `CopyMapper` found [here](https://github.com/inducer/pytato/blob/ae413329e615063c5fc6531cf9ca66d677d4157d/pytato/transform/__init__.py#L264-L266)