### PR TITLE
Update to pass *args and **kwargs through

### DIFF
--- a/pytato/transform/__init__.py
+++ b/pytato/transform/__init__.py
@@ -475,7 +475,7 @@ class CopyMapperWithExtraArgs(CachedMapper[ArrayOrNames]):
     def map_index_lambda(self, expr: IndexLambda,
                          *args: Any, **kwargs: Any) -> Array:
         bindings: Mapping[str, Array] = immutabledict({
-                name: self.rec(subexpr)
+                name: self.rec(subexpr, *args, **kwargs) # Make sure to pass the args through.
                 for name, subexpr in sorted(expr.bindings.items())})
         return IndexLambda(expr=expr.expr,
                            shape=self.rec_idx_or_size_tuple(expr.shape,

--- a/pytato/transform/__init__.py
+++ b/pytato/transform/__init__.py
@@ -475,7 +475,7 @@ class CopyMapperWithExtraArgs(CachedMapper[ArrayOrNames]):
     def map_index_lambda(self, expr: IndexLambda,
                          *args: Any, **kwargs: Any) -> Array:
         bindings: Mapping[str, Array] = immutabledict({
-                name: self.rec(subexpr, *args, **kwargs) # Make sure to pass the args through.
+                name: self.rec(subexpr, *args, **kwargs)
                 for name, subexpr in sorted(expr.bindings.items())})
         return IndexLambda(expr=expr.expr,
                            shape=self.rec_idx_or_size_tuple(expr.shape,
@@ -539,7 +539,7 @@ class CopyMapperWithExtraArgs(CachedMapper[ArrayOrNames]):
                                           expr: AdvancedIndexInNoncontiguousAxes,
                                           *args: Any, **kwargs: Any
                                           ) -> Array:
-        return self._map_index_base(expr)
+        return self._map_index_base(expr, *args, **kwargs)
 
     def map_data_wrapper(self, expr: DataWrapper,
                          *args: Any, **kwargs: Any) -> Array:


### PR DESCRIPTION
When copying an IndexLambda with the CopyMapperAndExtraArgs we do not pass the extra arguments to the dispatcher looking at the subexpressions.