### PR TITLE
Require arrays to have a `CreatedAt` tag if traceback tagging is enabled

### DIFF
--- a/pytato/array.py
+++ b/pytato/array.py
@@ -449,9 +449,9 @@ class Array(Taggable):
     tags: FrozenSet[Tag] = attrs.field(kw_only=True)
 
     # These are automatically excluded from equality in EqualityComparer
-    non_equality_tags: FrozenSet[Optional[Tag]] = attrs.field(kw_only=True,
-                                                              hash=False,
-                                                              default=frozenset())
+    non_equality_tags: FrozenSet[Tag] = attrs.field(kw_only=True,
+                                                    hash=False,
+                                                    default=frozenset())
 
     _mapper_method: ClassVar[str]
 

--- a/pytato/codegen.py
+++ b/pytato/codegen.py
@@ -117,7 +117,10 @@ class CodeGenPreprocessor(ToIndexLambdaMixin, CopyMapper):  # type: ignore[misc]
     def map_size_param(self, expr: SizeParam) -> Array:
         name = expr.name
         assert name is not None
-        return SizeParam(name, tags=expr.tags)
+        return SizeParam(
+            name=name,
+            tags=expr.tags,
+            non_equality_tags=expr.non_equality_tags)
 
     def map_placeholder(self, expr: Placeholder) -> Array:
         name = expr.name
@@ -128,7 +131,8 @@ class CodeGenPreprocessor(ToIndexLambdaMixin, CopyMapper):  # type: ignore[misc]
                             for s in expr.shape),
                 dtype=expr.dtype,
                 axes=expr.axes,
-                tags=expr.tags)
+                tags=expr.tags,
+                non_equality_tags=expr.non_equality_tags)
 
     def map_loopy_call(self, expr: LoopyCall) -> LoopyCall:
         from pytato.target.loopy import LoopyTarget
@@ -193,7 +197,8 @@ class CodeGenPreprocessor(ToIndexLambdaMixin, CopyMapper):  # type: ignore[misc]
                             for s in expr.shape),
                 dtype=expr.dtype,
                 axes=expr.axes,
-                tags=expr.tags)
+                tags=expr.tags,
+                non_equality_tags=expr.non_equality_tags)
 
     def map_named_call_result(self, expr: NamedCallResult) -> Array:
         raise NotImplementedError("CodeGenPreprocessor does not support functions.")

--- a/pytato/distributed/nodes.py
+++ b/pytato/distributed/nodes.py
@@ -148,7 +148,7 @@ class DistributedSendRefHolder(Array):
 
     def __init__(self, send: DistributedSend, passthrough_data: Array,
                  tags: FrozenSet[Tag] = frozenset(),
-                 non_equality_tags: FrozenSet[Optional[Tag]] = frozenset()) -> None:
+                 non_equality_tags: FrozenSet[Tag] = frozenset()) -> None:
         super().__init__(axes=passthrough_data.axes, tags=tags,
                          non_equality_tags=non_equality_tags)
         object.__setattr__(self, "send", send)
@@ -232,7 +232,7 @@ def make_distributed_send_ref_holder(
         send: DistributedSend,
         passthrough_data: Array,
         tags: FrozenSet[Tag] = frozenset(),
-        non_equality_tags: FrozenSet[Optional[Tag]] = frozenset(),
+        non_equality_tags: FrozenSet[Tag] = frozenset(),
         ) -> DistributedSendRefHolder:
     """Make a :class:`DistributedSendRefHolder` object."""
     if not non_equality_tags:

--- a/pytato/function.py
+++ b/pytato/function.py
@@ -230,7 +230,9 @@ class NamedCallResult(NamedArray):
                  name: str) -> None:
         super().__init__(call, name,
                          axes=call.function.returns[name].axes,
-                         tags=call.function.returns[name].tags)
+                         tags=call.function.returns[name].tags,
+                         non_equality_tags=(
+                             call.function.returns[name].non_equality_tags))
 
     def with_tagged_axis(self, iaxis: int,
                          tags: Union[Sequence[Tag], Tag]) -> Array:

--- a/pytato/transform/__init__.py
+++ b/pytato/transform/__init__.py
@@ -338,7 +338,11 @@ class CopyMapper(CachedMapper[ArrayOrNames]):
 
     def map_size_param(self, expr: SizeParam) -> Array:
         assert expr.name is not None
-        return SizeParam(expr.name, axes=expr.axes, tags=expr.tags)
+        return SizeParam(
+            name=expr.name,
+            axes=expr.axes,
+            tags=expr.tags,
+            non_equality_tags=expr.non_equality_tags)
 
     def map_einsum(self, expr: Einsum) -> Array:
         return Einsum(expr.access_descriptors,
@@ -401,7 +405,8 @@ class CopyMapper(CachedMapper[ArrayOrNames]):
                     dest_rank=expr.send.dest_rank,
                     comm_tag=expr.send.comm_tag),
                 self.rec(expr.passthrough_data),
-                tags=expr.tags)
+                tags=expr.tags,
+                non_equality_tags=expr.non_equality_tags)
 
     def map_distributed_recv(self, expr: DistributedRecv) -> Array:
         return DistributedRecv(
@@ -619,7 +624,8 @@ class CopyMapperWithExtraArgs(CachedMapper[ArrayOrNames]):
                 container=rec_loopy_call,
                 name=expr.name,
                 axes=expr.axes,
-                tags=expr.tags)
+                tags=expr.tags,
+                non_equality_tags=expr.non_equality_tags)
 
     def map_reshape(self, expr: Reshape,
                     *args: Any, **kwargs: Any) -> Array:
@@ -1457,7 +1463,8 @@ class MPMSMaterializer(Mapper):
                                  tags=expr.send.tags),
             passthrough_data=rec_passthrough.expr,
             tags=expr.tags,
-        )
+            non_equality_tags=expr.non_equality_tags,
+            )
         return MPMSMaterializerAccumulator(
             rec_passthrough.materialized_predecessors, new_expr)
 

--- a/pytato/transform/lower_to_index_lambda.py
+++ b/pytato/transform/lower_to_index_lambda.py
@@ -101,7 +101,8 @@ class ToIndexLambdaMixin:
                                          in sorted(expr.bindings.items())}),
                            axes=expr.axes,
                            var_to_reduction_descr=expr.var_to_reduction_descr,
-                           tags=expr.tags)
+                           tags=expr.tags,
+                           non_equality_tags=expr.non_equality_tags)
 
     def map_stack(self, expr: Stack) -> IndexLambda:
         subscript = tuple(prim.Variable(f"_{i}")
@@ -135,7 +136,8 @@ class ToIndexLambdaMixin:
                            axes=expr.axes,
                            bindings=immutabledict(bindings),
                            var_to_reduction_descr=immutabledict(),
-                           tags=expr.tags)
+                           tags=expr.tags,
+                           non_equality_tags=expr.non_equality_tags)
 
     def map_concatenate(self, expr: Concatenate) -> IndexLambda:
         from pymbolic.primitives import If, Comparison, Subscript
@@ -183,7 +185,8 @@ class ToIndexLambdaMixin:
                            bindings=immutabledict(bindings),
                            axes=expr.axes,
                            var_to_reduction_descr=immutabledict(),
-                           tags=expr.tags)
+                           tags=expr.tags,
+                           non_equality_tags=expr.non_equality_tags)
 
     def map_einsum(self, expr: Einsum) -> IndexLambda:
         import operator
@@ -252,7 +255,8 @@ class ToIndexLambdaMixin:
                            bindings=immutabledict(bindings),
                            axes=expr.axes,
                            var_to_reduction_descr=immutabledict(var_to_redn_descr),
-                           tags=expr.tags)
+                           tags=expr.tags,
+                           non_equality_tags=expr.non_equality_tags)
 
     def map_roll(self, expr: Roll) -> IndexLambda:
         from pytato.utils import dim_to_index_lambda_components
@@ -279,7 +283,8 @@ class ToIndexLambdaMixin:
                                      for name, bnd in bindings.items()}),
                            axes=expr.axes,
                            var_to_reduction_descr=immutabledict(),
-                           tags=expr.tags)
+                           tags=expr.tags,
+                           non_equality_tags=expr.non_equality_tags)
 
     def map_contiguous_advanced_index(self,
                                       expr: AdvancedIndexInContiguousAxes
@@ -344,6 +349,7 @@ class ToIndexLambdaMixin:
                            axes=expr.axes,
                            var_to_reduction_descr=immutabledict(),
                            tags=expr.tags,
+                           non_equality_tags=expr.non_equality_tags,
                            )
 
     def map_non_contiguous_advanced_index(
@@ -406,6 +412,7 @@ class ToIndexLambdaMixin:
                            axes=expr.axes,
                            var_to_reduction_descr=immutabledict(),
                            tags=expr.tags,
+                           non_equality_tags=expr.non_equality_tags,
                            )
 
     def map_basic_index(self, expr: BasicIndex) -> IndexLambda:
@@ -439,6 +446,7 @@ class ToIndexLambdaMixin:
                            axes=expr.axes,
                            var_to_reduction_descr=immutabledict(),
                            tags=expr.tags,
+                           non_equality_tags=expr.non_equality_tags,
                            )
 
     def map_reshape(self, expr: Reshape) -> IndexLambda:
@@ -450,7 +458,8 @@ class ToIndexLambdaMixin:
                            bindings=immutabledict({"_in0": self.rec(expr.array)}),
                            axes=expr.axes,
                            var_to_reduction_descr=immutabledict(),
-                           tags=expr.tags)
+                           tags=expr.tags,
+                           non_equality_tags=expr.non_equality_tags)
 
     def map_axis_permutation(self, expr: AxisPermutation) -> IndexLambda:
         indices = [None] * expr.ndim
@@ -465,7 +474,8 @@ class ToIndexLambdaMixin:
                            bindings=immutabledict({"_in0": self.rec(expr.array)}),
                            axes=expr.axes,
                            var_to_reduction_descr=immutabledict(),
-                           tags=expr.tags)
+                           tags=expr.tags,
+                           non_equality_tags=expr.non_equality_tags)
 
 
 class ToIndexLambdaMapper(Mapper, ToIndexLambdaMixin):

--- a/pytato/utils.py
+++ b/pytato/utils.py
@@ -180,7 +180,7 @@ def broadcast_binary_op(a1: ArrayOrScalar, a2: ArrayOrScalar,
                         op: Callable[[ScalarExpression, ScalarExpression], ScalarExpression],  # noqa:E501
                         get_result_type: Callable[[DtypeOrScalar, DtypeOrScalar], np.dtype[Any]],  # noqa:E501
                         tags: FrozenSet[Tag],
-                        non_equality_tags: FrozenSet[Optional[Tag]],
+                        non_equality_tags: FrozenSet[Tag],
                         ) -> ArrayOrScalar:
     from pytato.array import _get_default_axes
 
@@ -481,7 +481,7 @@ def _index_into(
         ary: Array,
         indices: Tuple[ConvertibleToIndexExpr, ...],
         tags: FrozenSet[Tag],
-        non_equality_tags: FrozenSet[Optional[Tag]]) -> Array:
+        non_equality_tags: FrozenSet[Tag]) -> Array:
     from pytato.diagnostic import CannotBroadcastError
     from pytato.array import _get_default_axes
 


### PR DESCRIPTION
Also, make sure `non_equality_tags` gets propagated through mappers.

