### PR TITLE
Add `TransformMapper`/`TransformMapperWithExtraArgs`

### DIFF
--- a/pytato/transform/__init__.py
+++ b/pytato/transform/__init__.py
@@ -474,6 +474,8 @@ class CopyMapperWithExtraArgs(CachedMapper[ArrayOrNames]):
 
     The logic in :class:`CopyMapper` purposely does not take the extra
     arguments to keep the cost of its each call frame low.
+
+    .. automethod:: clone_for_callee
     """
     def __init__(self) -> None:
         super().__init__()
@@ -507,6 +509,14 @@ class CopyMapperWithExtraArgs(CachedMapper[ArrayOrNames]):
             self._cache[key] = result
             # type-ignore-reason: Mapper.rec is imprecise
             return result  # type: ignore[no-any-return]
+
+    def clone_for_callee(
+            self: _SelfMapper, function: FunctionDefinition) -> _SelfMapper:
+        """
+        Called to clone *self* before starting traversal of a
+        :class:`pytato.function.FunctionDefinition`.
+        """
+        return type(self)()
 
     def rec_idx_or_size_tuple(self, situp: tuple[IndexOrShapeExpr, ...],
                               *args: Any, **kwargs: Any

--- a/pytato/transform/__init__.py
+++ b/pytato/transform/__init__.py
@@ -232,6 +232,8 @@ class CachedMapper(Mapper, Generic[CachedMapperT]):
     """Mapper class that maps each node in the DAG exactly once. This loses some
     information compared to :class:`Mapper` as a node is visited only from
     one of its predecessors.
+
+    .. automethod:: get_cache_key
     """
 
     def __init__(self) -> None:
@@ -263,6 +265,10 @@ class CachedMapper(Mapper, Generic[CachedMapperT]):
 class TransformMapper(CachedMapper[ArrayOrNames]):
     """Base class for mappers that transform :class:`pytato.array.Array`\\ s into
     other :class:`pytato.array.Array`\\ s.
+
+    Enables certain operations that can only be done if the mapping results are also
+    arrays (e.g., calling :meth:`~CachedMapper.get_cache_key` on them). Does not
+    implement default mapper methods; for that, see :class:`CopyMapper`.
 
     .. automethod:: clone_for_callee
     """


### PR DESCRIPTION
Adds `TransformMapper`/`TransformMapperWithExtraArgs` which represent generic mappers that map from arrays to other arrays. Separates out the caching/cloning parts of `CopyMapper`/`CopyMapperWithExtraArgs` so that other mappers can reuse them without also having to inherit the default mapper method implementations.

(Possibly easier to read commit by commit, the diff is a little messed up.)