### PR TITLE
Cache mapped functions

### DIFF
--- a/pytato/analysis/__init__.py
+++ b/pytato/analysis/__init__.py
@@ -26,7 +26,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Never
 
 from typing_extensions import Self
 
@@ -318,7 +318,7 @@ def is_einsum_similar_to_subscript(expr: Einsum, subscripts: str) -> bool:
 
 # {{{ DirectPredecessorsGetter
 
-class DirectPredecessorsGetter(Mapper[frozenset[ArrayOrNames], None, []]):
+class DirectPredecessorsGetter(Mapper[frozenset[ArrayOrNames], Never, []]):
     """
     Mapper to get the
     `direct predecessors

--- a/pytato/distributed/partition.py
+++ b/pytato/distributed/partition.py
@@ -288,8 +288,9 @@ class _DistributedInputReplacer(CopyMapper):
                  recvd_ary_to_name: Mapping[Array, str],
                  sptpo_ary_to_name: Mapping[Array, str],
                  name_to_output: Mapping[str, Array],
+                 _function_cache: dict[Hashable, FunctionDefinition] | None = None,
                  ) -> None:
-        super().__init__()
+        super().__init__(_function_cache=_function_cache)
 
         self.recvd_ary_to_name = recvd_ary_to_name
         self.sptpo_ary_to_name = sptpo_ary_to_name
@@ -303,7 +304,7 @@ class _DistributedInputReplacer(CopyMapper):
             self, function: FunctionDefinition) -> _DistributedInputReplacer:
         # Function definitions aren't allowed to contain receives,
         # stored arrays promoted to part outputs, or part outputs
-        return type(self)({}, {}, {})
+        return type(self)({}, {}, {}, _function_cache=self._function_cache)
 
     def map_placeholder(self, expr: Placeholder) -> Placeholder:
         self.user_input_names.add(expr.name)
@@ -456,7 +457,7 @@ def _recv_to_comm_id(
 
 
 class _LocalSendRecvDepGatherer(
-        CombineMapper[frozenset[CommunicationOpIdentifier]]):
+        CombineMapper[frozenset[CommunicationOpIdentifier], None]):
     def __init__(self, local_rank: int) -> None:
         super().__init__()
         self.local_comm_ids_to_needed_comm_ids: \

--- a/pytato/distributed/partition.py
+++ b/pytato/distributed/partition.py
@@ -70,6 +70,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Generic,
+    Never,
     TypeVar,
     cast,
 )
@@ -457,7 +458,7 @@ def _recv_to_comm_id(
 
 
 class _LocalSendRecvDepGatherer(
-        CombineMapper[frozenset[CommunicationOpIdentifier], None]):
+        CombineMapper[frozenset[CommunicationOpIdentifier], Never]):
     def __init__(self, local_rank: int) -> None:
         super().__init__()
         self.local_comm_ids_to_needed_comm_ids: \

--- a/pytato/distributed/partition.py
+++ b/pytato/distributed/partition.py
@@ -90,7 +90,13 @@ from pytato.distributed.nodes import (
     DistributedSendRefHolder,
 )
 from pytato.scalar_expr import SCALAR_CLASSES
-from pytato.transform import ArrayOrNames, CachedWalkMapper, CombineMapper, CopyMapper
+from pytato.transform import (
+    ArrayOrNames,
+    CachedWalkMapper,
+    CombineMapper,
+    CopyMapper,
+    _verify_is_array,
+)
 
 
 if TYPE_CHECKING:
@@ -396,7 +402,7 @@ def _make_distributed_partition(
 
         for name, val in name_to_part_output.items():
             assert name not in name_to_output
-            name_to_output[name] = comm_replacer.rec_ary(val)
+            name_to_output[name] = _verify_is_array(comm_replacer.rec(val))
 
         comm_ids = part_comm_ids[part_id]
 

--- a/pytato/distributed/verify.py
+++ b/pytato/distributed/verify.py
@@ -144,8 +144,8 @@ class MissingRecvError(DistributedPartitionVerificationError):
 
 @optimize_mapper(drop_args=True, drop_kwargs=True, inline_get_cache_key=True)
 class _SeenNodesWalkMapper(CachedWalkMapper[[]]):
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, _visited_functions: set[Any] | None = None) -> None:
+        super().__init__(_visited_functions=_visited_functions)
         self.seen_nodes: set[ArrayOrNames] = set()
 
     def get_cache_key(self, expr: ArrayOrNames) -> int:

--- a/pytato/equality.py
+++ b/pytato/equality.py
@@ -27,8 +27,6 @@ THE SOFTWARE.
 
 from typing import TYPE_CHECKING, Any
 
-from pytools import memoize_method
-
 from pytato.array import (
     AbstractResultWithNamedArrays,
     AdvancedIndexInContiguousAxes,
@@ -49,13 +47,14 @@ from pytato.array import (
     SizeParam,
     Stack,
 )
+from pytato.function import FunctionDefinition
 
 
 if TYPE_CHECKING:
     from collections.abc import Callable
 
     from pytato.distributed.nodes import DistributedRecv, DistributedSendRefHolder
-    from pytato.function import Call, FunctionDefinition, NamedCallResult
+    from pytato.function import Call, NamedCallResult
     from pytato.loopy import LoopyCall, LoopyCallResult
 
 __doc__ = """
@@ -85,26 +84,31 @@ class EqualityComparer:
           more on this.
     """
     def __init__(self) -> None:
+        # Uses the same cache for both arrays and functions
         self._cache: dict[tuple[int, int], bool] = {}
 
-    def rec(self, expr1: ArrayOrNames, expr2: Any) -> bool:
+    def rec(self, expr1: ArrayOrNames | FunctionDefinition, expr2: Any) -> bool:
         cache_key = id(expr1), id(expr2)
         try:
             return self._cache[cache_key]
         except KeyError:
-
-            method: Callable[[Array | AbstractResultWithNamedArrays, Any],
-                             bool]
-
-            try:
-                method = getattr(self, expr1._mapper_method)
-            except AttributeError:
-                if isinstance(expr1, Array):
-                    result = self.handle_unsupported_array(expr1, expr2)
+            if expr1 is expr2:
+                result = True
+            elif isinstance(expr1, ArrayOrNames):
+                method: Callable[[ArrayOrNames, Any], bool]
+                try:
+                    method = getattr(self, expr1._mapper_method)
+                except AttributeError:
+                    if isinstance(expr1, Array):
+                        result = self.handle_unsupported_array(expr1, expr2)
+                    else:
+                        result = self.map_foreign(expr1, expr2)
                 else:
-                    result = self.map_foreign(expr1, expr2)
+                    result = method(expr1, expr2)
+            elif isinstance(expr1, FunctionDefinition):
+                result = self.map_function_definition(expr1, expr2)
             else:
-                result = (expr1 is expr2) or method(expr1, expr2)
+                result = self.map_foreign(expr1, expr2)
 
             self._cache[cache_key] = result
             return result
@@ -296,7 +300,6 @@ class EqualityComparer:
                 and expr1.tags == expr2.tags
                 )
 
-    @memoize_method
     def map_function_definition(self, expr1: FunctionDefinition, expr2: Any
                                 ) -> bool:
         return (expr1.__class__ is expr2.__class__
@@ -310,7 +313,7 @@ class EqualityComparer:
 
     def map_call(self, expr1: Call, expr2: Any) -> bool:
         return (expr1.__class__ is expr2.__class__
-                and self.map_function_definition(expr1.function, expr2.function)
+                and self.rec(expr1.function, expr2.function)
                 and frozenset(expr1.bindings) == frozenset(expr2.bindings)
                 and all(self.rec(bnd,
                                  expr2.bindings[name])

--- a/pytato/stringifier.py
+++ b/pytato/stringifier.py
@@ -31,8 +31,6 @@ from typing import TYPE_CHECKING, Any, cast
 import numpy as np
 from immutabledict import immutabledict
 
-from pytools import memoize_method
-
 from pytato.array import (
     Array,
     Axis,
@@ -58,7 +56,7 @@ __doc__ = """
 
 # {{{ Reprifier
 
-class Reprifier(Mapper[str, [int]]):
+class Reprifier(Mapper[str, str, [int]]):
     """
     Stringifies :mod:`pytato`-types to closely resemble CPython's implementation
     of :func:`repr` for its builtin datatypes.
@@ -71,6 +69,7 @@ class Reprifier(Mapper[str, [int]]):
         self.truncation_depth = truncation_depth
         self.truncation_string = truncation_string
 
+        # Uses the same cache for both arrays and functions
         self._cache: dict[tuple[int, int], str] = {}
 
     def rec(self, expr: Any, depth: int) -> str:
@@ -79,6 +78,15 @@ class Reprifier(Mapper[str, [int]]):
             return self._cache[cache_key]
         except KeyError:
             result = super().rec(expr, depth)
+            self._cache[cache_key] = result
+            return result
+
+    def rec_function_definition(self, expr: FunctionDefinition, depth: int) -> str:
+        cache_key = (id(expr), depth)
+        try:
+            return self._cache[cache_key]
+        except KeyError:
+            result = super().rec_function_definition(expr, depth)
             self._cache[cache_key] = result
             return result
 
@@ -171,7 +179,6 @@ class Reprifier(Mapper[str, [int]]):
                         for field in dataclasses.fields(type(expr)))
                 + ")")
 
-    @memoize_method
     def map_function_definition(self, expr: FunctionDefinition, depth: int) -> str:
         if depth > self.truncation_depth:
             return self.truncation_string
@@ -194,7 +201,7 @@ class Reprifier(Mapper[str, [int]]):
 
         def _get_field_val(field: str) -> str:
             if field == "function":
-                return self.map_function_definition(expr.function, depth+1)
+                return self.rec_function_definition(expr.function, depth+1)
             else:
                 return self.rec(getattr(expr, field), depth+1)
 

--- a/pytato/stringifier.py
+++ b/pytato/stringifier.py
@@ -39,7 +39,7 @@ from pytato.array import (
     IndexLambda,
     ReductionDescriptor,
 )
-from pytato.transform import Mapper
+from pytato.transform import ForeignObjectError, Mapper
 
 
 if TYPE_CHECKING:
@@ -77,7 +77,10 @@ class Reprifier(Mapper[str, str, [int]]):
         try:
             return self._cache[cache_key]
         except KeyError:
-            result = super().rec(expr, depth)
+            try:
+                result = super().rec(expr, depth)
+            except ForeignObjectError:
+                result = self.map_foreign(expr, depth)
             self._cache[cache_key] = result
             return result
 

--- a/pytato/target/loopy/codegen.py
+++ b/pytato/target/loopy/codegen.py
@@ -384,7 +384,7 @@ class CodeGenState:
 
 # {{{ codegen mapper
 
-class CodeGenMapper(Mapper[ImplementedResult, [CodeGenState]]):
+class CodeGenMapper(Mapper[ImplementedResult, None, [CodeGenState]]):
     """A mapper for generating code for nodes in the computation graph.
     """
     exprgen_mapper: InlinedExpressionGenMapper

--- a/pytato/target/loopy/codegen.py
+++ b/pytato/target/loopy/codegen.py
@@ -28,7 +28,7 @@ import re
 import sys
 from abc import ABC, abstractmethod
 from collections.abc import Mapping
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Never
 
 import islpy as isl
 
@@ -384,7 +384,7 @@ class CodeGenState:
 
 # {{{ codegen mapper
 
-class CodeGenMapper(Mapper[ImplementedResult, None, [CodeGenState]]):
+class CodeGenMapper(Mapper[ImplementedResult, Never, [CodeGenState]]):
     """A mapper for generating code for nodes in the computation graph.
     """
     exprgen_mapper: InlinedExpressionGenMapper

--- a/pytato/target/python/numpy_like.py
+++ b/pytato/target/python/numpy_like.py
@@ -62,6 +62,7 @@ from pytato.array import (
     SizeParam,
     Stack,
 )
+from pytato.function import FunctionDefinition
 from pytato.raising import BinaryOpType, C99CallOp
 from pytato.reductions import (
     AllReductionOperation,
@@ -171,7 +172,7 @@ PYTATO_REDUCTION_TO_NP_REDUCTION: Mapping[type[ReductionOperation], str] = {
 }
 
 
-class NumpyCodegenMapper(CachedMapper[str, []]):
+class NumpyCodegenMapper(CachedMapper[str, FunctionDefinition, []]):
     """
     .. note::
 

--- a/pytato/target/python/numpy_like.py
+++ b/pytato/target/python/numpy_like.py
@@ -30,6 +30,7 @@ import os
 import sys
 from typing import (
     TYPE_CHECKING,
+    Never,
     TypedDict,
     TypeVar,
     cast,
@@ -62,7 +63,6 @@ from pytato.array import (
     SizeParam,
     Stack,
 )
-from pytato.function import FunctionDefinition
 from pytato.raising import BinaryOpType, C99CallOp
 from pytato.reductions import (
     AllReductionOperation,
@@ -172,7 +172,7 @@ PYTATO_REDUCTION_TO_NP_REDUCTION: Mapping[type[ReductionOperation], str] = {
 }
 
 
-class NumpyCodegenMapper(CachedMapper[str, FunctionDefinition, []]):
+class NumpyCodegenMapper(CachedMapper[str, Never, []]):
     """
     .. note::
 

--- a/pytato/transform/__init__.py
+++ b/pytato/transform/__init__.py
@@ -770,12 +770,14 @@ class CombineMapper(Mapper[ResultT, FunctionResultT, []]):
 
     .. automethod:: combine
     """
-    def __init__(self) -> None:
+    def __init__(
+            self,
+            _function_cache: dict[FunctionDefinition, FunctionResultT] | None = None
+            ) -> None:
         super().__init__()
         self.cache: dict[ArrayOrNames, ResultT] = {}
-        # Don't need to pass function cache as argument here, because unlike
-        # CachedMapper we're not creating a new mapper for each call
-        self.function_cache: dict[FunctionDefinition, FunctionResultT] = {}
+        self.function_cache: dict[FunctionDefinition, FunctionResultT] = \
+            _function_cache if _function_cache is not None else {}
 
     def rec_idx_or_size_tuple(self, situp: tuple[IndexOrShapeExpr, ...]
                               ) -> tuple[ResultT, ...]:

--- a/pytato/transform/__init__.py
+++ b/pytato/transform/__init__.py
@@ -332,8 +332,7 @@ class TransformMapper(CachedMapper[ArrayOrNames, FunctionDefinition, []]):
 # {{{ TransformMapperWithExtraArgs
 
 class TransformMapperWithExtraArgs(
-            CachedMapper[ArrayOrNames, FunctionDefinition, P],
-            Mapper[ArrayOrNames, FunctionDefinition, P]
+            CachedMapper[ArrayOrNames, FunctionDefinition, P]
         ):
     """
     Similar to :class:`TransformMapper`, but each mapper method takes extra

--- a/pytato/transform/__init__.py
+++ b/pytato/transform/__init__.py
@@ -1308,15 +1308,17 @@ class CachedWalkMapper(WalkMapper[P]):
         self._visited_functions: set[Any] = \
             _visited_functions if _visited_functions is not None else set()
 
-    def get_cache_key(self, expr: ArrayOrNames, *args: Any, **kwargs: Any) -> Any:
+    def get_cache_key(
+            self, expr: ArrayOrNames, *args: P.args, **kwargs: P.kwargs
+            ) -> Any:
         raise NotImplementedError
 
     def get_function_definition_cache_key(
-            self, expr: FunctionDefinition, *args: Any, **kwargs: Any) -> Any:
+            self, expr: FunctionDefinition, *args: P.args, **kwargs: P.kwargs
+            ) -> Any:
         raise NotImplementedError
 
-    def rec(self, expr: ArrayOrNames, *args: Any, **kwargs: Any
-            ) -> None:
+    def rec(self, expr: ArrayOrNames, *args: P.args, **kwargs: P.kwargs) -> None:
         cache_key = self.get_cache_key(expr, *args, **kwargs)
         if cache_key in self._visited_arrays_or_names:
             return
@@ -1325,7 +1327,7 @@ class CachedWalkMapper(WalkMapper[P]):
         self._visited_arrays_or_names.add(cache_key)
 
     def rec_function_definition(self, expr: FunctionDefinition,
-                                *args: Any, **kwargs: Any) -> None:
+                                *args: P.args, **kwargs: P.kwargs) -> None:
         cache_key = self.get_function_definition_cache_key(expr, *args, **kwargs)
         if cache_key in self._visited_functions:
             return

--- a/pytato/transform/__init__.py
+++ b/pytato/transform/__init__.py
@@ -28,6 +28,7 @@ THE SOFTWARE.
 """
 import dataclasses
 import logging
+from collections.abc import Hashable
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -80,7 +81,7 @@ from pytato.tags import ImplStored
 
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Hashable, Iterable, Mapping
+    from collections.abc import Callable, Iterable, Mapping
 
 
 ArrayOrNames: TypeAlias = Array | AbstractResultWithNamedArrays
@@ -1292,6 +1293,9 @@ class WalkMapper(Mapper[None, None, P]):
 
 # {{{ CachedWalkMapper
 
+VisitKeyT: TypeAlias = Hashable
+
+
 class CachedWalkMapper(WalkMapper[P]):
     """
     WalkMapper that visits each node in the DAG exactly once. This loses some
@@ -1301,21 +1305,22 @@ class CachedWalkMapper(WalkMapper[P]):
 
     def __init__(
             self,
-            _visited_functions: set[Any] | None = None) -> None:
+            _visited_functions: set[VisitKeyT] | None = None
+            ) -> None:
         super().__init__()
-        self._visited_arrays_or_names: set[Any] = set()
+        self._visited_arrays_or_names: set[VisitKeyT] = set()
 
-        self._visited_functions: set[Any] = \
+        self._visited_functions: set[VisitKeyT] = \
             _visited_functions if _visited_functions is not None else set()
 
     def get_cache_key(
             self, expr: ArrayOrNames, *args: P.args, **kwargs: P.kwargs
-            ) -> Any:
+            ) -> VisitKeyT:
         raise NotImplementedError
 
     def get_function_definition_cache_key(
             self, expr: FunctionDefinition, *args: P.args, **kwargs: P.kwargs
-            ) -> Any:
+            ) -> VisitKeyT:
         raise NotImplementedError
 
     def rec(self, expr: ArrayOrNames, *args: P.args, **kwargs: P.kwargs) -> None:
@@ -1357,7 +1362,7 @@ class TopoSortMapper(CachedWalkMapper[[]]):
 
     def __init__(
             self,
-            _visited_functions: set[Any] | None = None) -> None:
+            _visited_functions: set[VisitKeyT] | None = None) -> None:
         super().__init__(_visited_functions=_visited_functions)
         self.topological_order: list[Array] = []
 

--- a/pytato/transform/__init__.py
+++ b/pytato/transform/__init__.py
@@ -194,7 +194,7 @@ class Mapper(Generic[ResultT, FunctionResultT, P]):
     .. automethod:: __call__
     """
 
-    def handle_unsupported_array(self, expr: MappedT,
+    def handle_unsupported_array(self, expr: Array,
                                  *args: P.args, **kwargs: P.kwargs) -> ResultT:
         """Mapper method that is invoked for
         :class:`pytato.Array` subclasses for which a mapper

--- a/pytato/transform/__init__.py
+++ b/pytato/transform/__init__.py
@@ -204,7 +204,7 @@ class Mapper(Generic[ResultT, FunctionResultT, P]):
 
     def rec(self, expr: ArrayOrNames, *args: P.args, **kwargs: P.kwargs) -> ResultT:
         """Call the mapper method of *expr* and return the result."""
-        method: Callable[..., Any] | None
+        method: Callable[..., ResultT] | None
 
         try:
             method = getattr(self, expr._mapper_method)
@@ -230,7 +230,7 @@ class Mapper(Generic[ResultT, FunctionResultT, P]):
             self, expr: FunctionDefinition, *args: P.args, **kwargs: P.kwargs
             ) -> FunctionResultT:
         """Call the mapper method of *expr* and return the result."""
-        method: Callable[..., Any] | None
+        method: Callable[..., FunctionResultT] | None
 
         try:
             method = self.map_function_definition  # type: ignore[attr-defined]
@@ -239,7 +239,7 @@ class Mapper(Generic[ResultT, FunctionResultT, P]):
                 f"{type(self).__name__} lacks a mapper method for functions.") from None
 
         assert method is not None
-        return cast("FunctionResultT", method(expr, *args, **kwargs))
+        return method(expr, *args, **kwargs)
 
     def __call__(self,
                  expr: ArrayOrNames, *args: P.args, **kwargs: P.kwargs) -> ResultT:

--- a/pytato/transform/__init__.py
+++ b/pytato/transform/__init__.py
@@ -32,6 +32,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Generic,
+    Never,
     ParamSpec,
     TypeAlias,
     TypeVar,
@@ -1434,7 +1435,7 @@ def _materialize_if_mpms(expr: Array,
         return MPMSMaterializerAccumulator(materialized_predecessors, expr)
 
 
-class MPMSMaterializer(Mapper[MPMSMaterializerAccumulator, None, []]):
+class MPMSMaterializer(Mapper[MPMSMaterializerAccumulator, Never, []]):
     """
     See :func:`materialize_with_mpms` for an explanation.
 
@@ -1711,7 +1712,7 @@ def materialize_with_mpms(expr: DictOfNamedArrays) -> DictOfNamedArrays:
 
 # {{{ UsersCollector
 
-class UsersCollector(CachedMapper[None, None, []]):
+class UsersCollector(CachedMapper[None, Never, []]):
     """
     Maps a graph to a dictionary representation mapping a node to its users,
     i.e. all the nodes using its value.

--- a/pytato/transform/__init__.py
+++ b/pytato/transform/__init__.py
@@ -265,12 +265,8 @@ class CachedMapper(Mapper[ResultT, FunctionResultT, P]):
         super().__init__()
         self._cache: dict[Hashable, ResultT] = {}
 
-        if _function_cache is not None:
-            function_cache = _function_cache
-        else:
-            function_cache = {}
-
-        self._function_cache: dict[Hashable, FunctionResultT] = function_cache
+        self._function_cache: dict[Hashable, FunctionResultT] = \
+            _function_cache if _function_cache is not None else {}
 
     def get_cache_key(
                 self, expr: ArrayOrNames, *args: P.args, **kwargs: P.kwargs
@@ -1303,12 +1299,8 @@ class CachedWalkMapper(WalkMapper[P]):
         super().__init__()
         self._visited_arrays_or_names: set[Any] = set()
 
-        if _visited_functions is not None:
-            visited_functions = _visited_functions
-        else:
-            visited_functions = set()
-
-        self._visited_functions: set[Any] = visited_functions
+        self._visited_functions: set[Any] = \
+            _visited_functions if _visited_functions is not None else set()
 
     def get_cache_key(self, expr: ArrayOrNames, *args: Any, **kwargs: Any) -> Any:
         raise NotImplementedError

--- a/pytato/transform/calls.py
+++ b/pytato/transform/calls.py
@@ -58,6 +58,7 @@ class PlaceholderSubstitutor(CopyMapper):
     """
 
     def __init__(self, substitutions: Mapping[str, Array]) -> None:
+        # Ignoring function cache, not needed
         super().__init__()
         self.substitutions = substitutions
 

--- a/pytato/transform/calls.py
+++ b/pytato/transform/calls.py
@@ -58,12 +58,16 @@ class PlaceholderSubstitutor(CopyMapper):
     """
 
     def __init__(self, substitutions: Mapping[str, Array]) -> None:
-        # Ignoring function cache, not needed
+        # Ignoring function cache, since we don't support functions anyway
         super().__init__()
         self.substitutions = substitutions
 
     def map_placeholder(self, expr: Placeholder) -> Array:
         return self.substitutions[expr.name]
+
+    def map_named_call_result(self, expr: NamedCallResult) -> NamedCallResult:
+        raise NotImplementedError(
+            "PlaceholderSubstitutor does not support functions.")
 
 
 class Inliner(CopyMapper):

--- a/pytato/transform/calls.py
+++ b/pytato/transform/calls.py
@@ -40,7 +40,7 @@ from pytato.array import (
 )
 from pytato.function import Call, NamedCallResult
 from pytato.tags import InlineCallTag
-from pytato.transform import ArrayOrNames, CopyMapper
+from pytato.transform import ArrayOrNames, CopyMapper, _verify_is_array
 
 
 if TYPE_CHECKING:
@@ -79,7 +79,7 @@ class Inliner(CopyMapper):
             substitutor = PlaceholderSubstitutor(new_expr.bindings)
 
             return DictOfNamedArrays(
-                {name: substitutor.rec_ary(ret)
+                {name: _verify_is_array(substitutor.rec(ret))
                  for name, ret in new_expr.function.returns.items()},
                 tags=new_expr.tags
             )

--- a/pytato/transform/lower_to_index_lambda.py
+++ b/pytato/transform/lower_to_index_lambda.py
@@ -29,7 +29,7 @@ THE SOFTWARE.
 """
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Never, TypeVar, cast
 
 from immutabledict import immutabledict
 
@@ -637,7 +637,7 @@ class ToIndexLambdaMixin:
                            non_equality_tags=expr.non_equality_tags)
 
 
-class ToIndexLambdaMapper(Mapper[Array, None, []], ToIndexLambdaMixin):
+class ToIndexLambdaMapper(Mapper[Array, Never, []], ToIndexLambdaMixin):
 
     def handle_unsupported_array(self, expr: Any) -> Any:
         raise CannotBeLoweredToIndexLambda(type(expr))

--- a/pytato/transform/lower_to_index_lambda.py
+++ b/pytato/transform/lower_to_index_lambda.py
@@ -637,7 +637,7 @@ class ToIndexLambdaMixin:
                            non_equality_tags=expr.non_equality_tags)
 
 
-class ToIndexLambdaMapper(Mapper[Array, []], ToIndexLambdaMixin):
+class ToIndexLambdaMapper(Mapper[Array, None, []], ToIndexLambdaMixin):
 
     def handle_unsupported_array(self, expr: Any) -> Any:
         raise CannotBeLoweredToIndexLambda(type(expr))

--- a/pytato/transform/lower_to_index_lambda.py
+++ b/pytato/transform/lower_to_index_lambda.py
@@ -639,7 +639,7 @@ class ToIndexLambdaMixin:
 
 class ToIndexLambdaMapper(Mapper[Array, Never, []], ToIndexLambdaMixin):
 
-    def handle_unsupported_array(self, expr: Any) -> Any:
+    def handle_unsupported_array(self, expr: Array) -> Array:
         raise CannotBeLoweredToIndexLambda(type(expr))
 
     def rec(self, expr: Array) -> Array:  # type: ignore[override]

--- a/pytato/transform/metadata.py
+++ b/pytato/transform/metadata.py
@@ -90,9 +90,9 @@ logger = logging.getLogger(__name__)
 
 
 if TYPE_CHECKING:
-    from collections.abc import Collection, Mapping
+    from collections.abc import Collection, Hashable, Mapping
 
-    from pytato.function import NamedCallResult
+    from pytato.function import FunctionDefinition, NamedCallResult
     from pytato.loopy import LoopyCall
 
 
@@ -101,7 +101,7 @@ GraphNodeT = TypeVar("GraphNodeT")
 
 # {{{ AxesTagsEquationCollector
 
-class AxesTagsEquationCollector(Mapper[None, []]):
+class AxesTagsEquationCollector(Mapper[None, None, []]):
     r"""
     Records equations arising from operand/output axes equivalence for an array
     operation. This mapper implements a default set of propagation rules,
@@ -595,8 +595,9 @@ class AxisTagAttacher(CopyMapper):
     """
     def __init__(self,
                  axis_to_tags: Mapping[tuple[Array, int], Collection[Tag]],
-                 tag_corresponding_redn_descr: bool):
-        super().__init__()
+                 tag_corresponding_redn_descr: bool,
+                 _function_cache: dict[Hashable, FunctionDefinition] | None = None):
+        super().__init__(_function_cache=_function_cache)
         self.axis_to_tags: Mapping[tuple[Array, int], Collection[Tag]] = axis_to_tags
         self.tag_corresponding_redn_descr: bool = tag_corresponding_redn_descr
 

--- a/pytato/transform/metadata.py
+++ b/pytato/transform/metadata.py
@@ -43,6 +43,7 @@ import logging
 from typing import (
     TYPE_CHECKING,
     Any,
+    Never,
     TypeVar,
     cast,
 )
@@ -101,7 +102,7 @@ GraphNodeT = TypeVar("GraphNodeT")
 
 # {{{ AxesTagsEquationCollector
 
-class AxesTagsEquationCollector(Mapper[None, None, []]):
+class AxesTagsEquationCollector(Mapper[None, Never, []]):
     r"""
     Records equations arising from operand/output axes equivalence for an array
     operation. This mapper implements a default set of propagation rules,

--- a/pytato/transform/metadata.py
+++ b/pytato/transform/metadata.py
@@ -42,7 +42,6 @@ THE SOFTWARE.
 import logging
 from typing import (
     TYPE_CHECKING,
-    Any,
     Never,
     TypeVar,
     cast,
@@ -602,7 +601,7 @@ class AxisTagAttacher(CopyMapper):
         self.axis_to_tags: Mapping[tuple[Array, int], Collection[Tag]] = axis_to_tags
         self.tag_corresponding_redn_descr: bool = tag_corresponding_redn_descr
 
-    def rec(self, expr: ArrayOrNames) -> Any:
+    def rec(self, expr: ArrayOrNames) -> ArrayOrNames:
         if isinstance(expr, AbstractResultWithNamedArrays | DistributedSendRefHolder):
             return super().rec(expr)
         else:

--- a/pytato/transform/remove_broadcasts_einsum.py
+++ b/pytato/transform/remove_broadcasts_einsum.py
@@ -31,7 +31,7 @@ THE SOFTWARE.
 from typing import cast
 
 from pytato.array import Array, Einsum, EinsumAxisDescriptor
-from pytato.transform import CopyMapper, MappedT
+from pytato.transform import CopyMapper, MappedT, _verify_is_array
 from pytato.utils import are_shape_components_equal
 
 
@@ -42,7 +42,7 @@ class EinsumWithNoBroadcastsRewriter(CopyMapper):
         descr_to_axis_len = expr._access_descr_to_axis_len()
 
         for acc_descrs, arg in zip(expr.access_descriptors, expr.args, strict=True):
-            arg = self.rec_ary(arg)
+            arg = _verify_is_array(self.rec(arg))
             axes_to_squeeze: list[int] = []
             for idim, acc_descr in enumerate(acc_descrs):
                 if not are_shape_components_equal(arg.shape[idim],

--- a/pytato/utils.py
+++ b/pytato/utils.py
@@ -269,7 +269,7 @@ def broadcast_binary_op(a1: ArrayOrScalar, a2: ArrayOrScalar,
 
 # {{{ dim_to_index_lambda_components
 
-class ShapeExpressionMapper(CachedMapper[ScalarExpression, []]):
+class ShapeExpressionMapper(CachedMapper[ScalarExpression, None, []]):
     """
     Mapper that takes a shape component and returns it as a scalar expression.
     """
@@ -372,7 +372,7 @@ def are_shapes_equal(shape1: ShapeType, shape2: ShapeType) -> bool:
 
 # {{{ ShapeToISLExpressionMapper
 
-class ShapeToISLExpressionMapper(CachedMapper[isl.Aff, []]):
+class ShapeToISLExpressionMapper(CachedMapper[isl.Aff, None, []]):
     """
     Mapper that takes a shape component and returns it as :class:`isl.Aff`.
     """

--- a/pytato/utils.py
+++ b/pytato/utils.py
@@ -25,6 +25,7 @@ THE SOFTWARE.
 from typing import (
     TYPE_CHECKING,
     Any,
+    Never,
     TypeVar,
     cast,
 )
@@ -269,7 +270,7 @@ def broadcast_binary_op(a1: ArrayOrScalar, a2: ArrayOrScalar,
 
 # {{{ dim_to_index_lambda_components
 
-class ShapeExpressionMapper(CachedMapper[ScalarExpression, None, []]):
+class ShapeExpressionMapper(CachedMapper[ScalarExpression, Never, []]):
     """
     Mapper that takes a shape component and returns it as a scalar expression.
     """
@@ -372,7 +373,7 @@ def are_shapes_equal(shape1: ShapeType, shape2: ShapeType) -> bool:
 
 # {{{ ShapeToISLExpressionMapper
 
-class ShapeToISLExpressionMapper(CachedMapper[isl.Aff, None, []]):
+class ShapeToISLExpressionMapper(CachedMapper[isl.Aff, Never, []]):
     """
     Mapper that takes a shape component and returns it as :class:`isl.Aff`.
     """

--- a/pytato/visualization/dot.py
+++ b/pytato/visualization/dot.py
@@ -197,8 +197,7 @@ class ArrayToDotNodeInfoMapper(CachedMapper[None, None, []]):
         return _DotNodeInfo(title, fields, edges)
 
     # type-ignore-reason: incompatible with supertype
-    def handle_unsupported_array(self,  # type: ignore[override]
-            expr: Array) -> None:
+    def handle_unsupported_array(self, expr: Array) -> None:
         # Default handler, does its best to guess how to handle fields.
         info = self.get_common_dot_info(expr)
 

--- a/pytato/visualization/dot.py
+++ b/pytato/visualization/dot.py
@@ -178,7 +178,7 @@ def stringify_shape(shape: ShapeType) -> str:
     return "(" + ", ".join(components) + ")"
 
 
-class ArrayToDotNodeInfoMapper(CachedMapper[ArrayOrNames, []]):
+class ArrayToDotNodeInfoMapper(CachedMapper[None, None, []]):
     def __init__(self) -> None:
         super().__init__()
         self.node_to_dot: dict[ArrayOrNames, _DotNodeInfo] = {}

--- a/pytato/visualization/fancy_placeholder_data_flow.py
+++ b/pytato/visualization/fancy_placeholder_data_flow.py
@@ -23,6 +23,7 @@ from pytato.array import (
     Placeholder,
     Stack,
 )
+from pytato.function import FunctionDefinition
 from pytato.transform import CachedMapper
 
 
@@ -100,7 +101,7 @@ def _get_dot_node_from_predecessors(node_id: str,
         return NoShowNode(), frozenset()
 
 
-class FancyDotWriter(CachedMapper[_FancyDotWriterNode, []]):
+class FancyDotWriter(CachedMapper[_FancyDotWriterNode, FunctionDefinition, []]):
     def __init__(self) -> None:
         super().__init__()
         self.vng = UniqueNameGenerator()

--- a/pytato/visualization/fancy_placeholder_data_flow.py
+++ b/pytato/visualization/fancy_placeholder_data_flow.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Never
 
 from pytools import UniqueNameGenerator
 
@@ -23,7 +23,6 @@ from pytato.array import (
     Placeholder,
     Stack,
 )
-from pytato.function import FunctionDefinition
 from pytato.transform import CachedMapper
 
 
@@ -101,7 +100,7 @@ def _get_dot_node_from_predecessors(node_id: str,
         return NoShowNode(), frozenset()
 
 
-class FancyDotWriter(CachedMapper[_FancyDotWriterNode, FunctionDefinition, []]):
+class FancyDotWriter(CachedMapper[_FancyDotWriterNode, Never, []]):
     def __init__(self) -> None:
         super().__init__()
         self.vng = UniqueNameGenerator()

--- a/test/testlib.py
+++ b/test/testlib.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
 
 # {{{ tools for comparison to numpy
 
-class NumpyBasedEvaluator(Mapper[Any, []]):
+class NumpyBasedEvaluator(Mapper[Any, None, []]):
     """
     Mapper to return the result according to an eager evaluation array package
     *np*.

--- a/test/testlib.py
+++ b/test/testlib.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import operator
 import random
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Never
 
 import numpy as np
 
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
 
 # {{{ tools for comparison to numpy
 
-class NumpyBasedEvaluator(Mapper[Any, None, []]):
+class NumpyBasedEvaluator(Mapper[Any, Never, []]):
     """
     Mapper to return the result according to an eager evaluation array package
     *np*.


### PR DESCRIPTION
Caches the results of mapping `FunctionDefinition`s. Caching is done globally to avoid re-traversing functions in different call stack frames.

Depends on ~~#503~~ (merged) and ~~#530~~ (merged).