### PR TITLE
Add missing `FunctionDefinition.__eq__`

### DIFF
--- a/pytato/function.py
+++ b/pytato/function.py
@@ -59,6 +59,7 @@ import enum
 import re
 from functools import cached_property
 from typing import (
+    Any,
     Callable,
     ClassVar,
     Hashable,
@@ -235,6 +236,15 @@ class FunctionDefinition(Taggable):
             return immutabledict({kw: call_site[kw] for kw in self.returns})
         else:
             raise NotImplementedError(self.return_type)
+
+    def __eq__(self, other: Any) -> bool:
+        if self is other:
+            return True
+        if not isinstance(other, FunctionDefinition):
+            return False
+
+        from pytato.equality import EqualityComparer
+        return EqualityComparer().map_function_definition(self, other)
 
 
 @attrs.frozen(eq=False, repr=False, hash=True, cache_hash=True)


### PR DESCRIPTION
Looks like `FunctionDefinition` is currently just using the `__eq__` that comes in from `Taggable`, which isn't right. I think for the most part this hasn't caused issues because `__hash__` is implemented correctly. _However_, in the implementation of `show_dot_graph`, the code creates a `list` of `FunctionDefinition`s and checks if a function is already in the list. The `in` operator for lists doesn't compare hashes first, so the code ended up treating two functions as the same when they weren't (they just had the same tags). This is what was causing the error I was seeing when trying to visualize the DAG in `test_nested_function_calls`.