### PR TITLE
Einsum lowered to IndexLambda variable name fix

### DIFF
--- a/pytato/transform/lower_to_index_lambda.py
+++ b/pytato/transform/lower_to_index_lambda.py
@@ -214,7 +214,7 @@ class ToIndexLambdaMixin:
             dim_to_index_lambda_components,
         )
 
-        bindings = {f"in{k}": self.rec(arg) for k, arg in enumerate(expr.args)}
+        bindings = {f"_in{k}": self.rec(arg) for k, arg in enumerate(expr.args)}
         redn_bounds: dict[str, tuple[ScalarExpression, ScalarExpression]] = {}
         args_as_pym_expr: list[prim.Subscript] = []
         namegen = UniqueNameGenerator(set(bindings))
@@ -253,7 +253,7 @@ class ToIndexLambdaMixin:
 
                     subscript_indices.append(prim.Variable(redn_idx_name))
 
-            args_as_pym_expr.append(prim.Subscript(prim.Variable(f"in{iarg}"),
+            args_as_pym_expr.append(prim.Subscript(prim.Variable(f"_in{iarg}"),
                                                    tuple(subscript_indices)))
 
         # }}}


### PR DESCRIPTION
The mapper to convert an Einsum to an IndexLambda we do not use the reserved variable names for the bindings. This PR intends to fix that.