### PR TITLE
[RFC] EqualityComparer: use data for DataWrapper comparison

### DIFF
--- a/pytato/equality.py
+++ b/pytato/equality.py
@@ -135,7 +135,10 @@ class EqualityComparer:
                 )
 
     def map_data_wrapper(self, expr1: DataWrapper, expr2: Any) -> bool:
-        return expr1 is expr2
+        import numpy as np
+        return (expr1.__class__ is expr2.__class__
+                and np.array_equal(expr1.data.get(), expr2.data.get())
+        )
 
     def map_index_lambda(self, expr1: IndexLambda, expr2: Any) -> bool:
         return (expr1.__class__ is expr2.__class__


### PR DESCRIPTION
Something like this is necessary to compare pickled/unpickled DataWrappers meaningfully.

I suspect this implementation is *slightly* controversial, but perhaps we could find a better way to implement this? (E.g., maybe calculating some hash over the data on DataWrapper construction?)