### PR TITLE
Revert "Any reductions in the scalar expression?"

### DIFF
--- a/pytato/scalar_expr.py
+++ b/pytato/scalar_expr.py
@@ -349,5 +349,5 @@ def contains_reduction(expr: prim.Expression) -> bool:
     Returns true if any operation in the scalar expression, expr, is a reduction
     operation.
     """
-    return bool(get_reduction_induction_variables(expr))
+    return (len(get_reduction_induction_variables(expr)) > 0)
 # vim: foldmethod=marker

--- a/pytato/scalar_expr.py
+++ b/pytato/scalar_expr.py
@@ -106,9 +106,6 @@ class WalkMapper(WalkMapperBase):
 
 
 class CombineMapper(CombineMapperBase):
-    def map_type_cast(self, expr: TypeCast, *args: Any, **kwargs: Any) -> Any:
-        return self.rec(expr.inner_expr)
-
     def map_reduce(self, expr: Reduce, *args: Any, **kwargs: Any) -> Any:
         return self.combine([*(self.rec(bnd, *args, **kwargs)
                                for _, bnd in sorted(expr.bounds.items())),
@@ -343,11 +340,4 @@ def get_reduction_induction_variables(expr: prim.Expression) -> frozenset[str]:
     """
     return InductionVariableCollector()(expr)  # type: ignore[no-any-return]
 
-
-def contains_reduction(expr: prim.Expression) -> bool:
-    """
-    Returns true if any operation in the scalar expression, expr, is a reduction
-    operation.
-    """
-    return (len(get_reduction_induction_variables(expr)) > 0)
 # vim: foldmethod=marker


### PR DESCRIPTION
Reverts inducer/pytato#555

It turns out this is not needed, hence I'm reverting this. A simpler way to check whether a node contains a reduction is to check https://documen.tician.de/pytato/array.html#pytato.array.IndexLambda.var_to_reduction_descr for non-emptiness.

cc @nkoskelo
