### PR TITLE
do not pickle cached hash of arrays

### DIFF
--- a/pytato/array.py
+++ b/pytato/array.py
@@ -367,6 +367,8 @@ def _augment_array_dataclass(
         from pytools.codegen import remove_common_indentation
         augment_code = remove_common_indentation(
             f"""
+            import dataclasses
+
             def {cls.__name__}_hash(self):
                 try:
                     return self._hash_value
@@ -379,12 +381,8 @@ def _augment_array_dataclass(
 
             cls.__hash__ = {cls.__name__}_hash
 
-            def {cls.__name__}_getstate(self):
-                # This must not return the cached hash value.
-                return {{name: val
-                for name, val in zip({fld_name_tuple}, {attr_tuple}, strict=True)}}
-
-            cls.__getstate__ = {cls.__name__}_getstate
+            cls.__getstate__ = dataclasses._dataclass_getstate
+            cls.__setstate__ = dataclasses._dataclass_setstate
             """)
         exec_dict = {"cls": cls, "_MODULE_SOURCE_CODE": augment_code}
         exec(compile(augment_code,

--- a/pytato/array.py
+++ b/pytato/array.py
@@ -369,6 +369,12 @@ def _augment_array_dataclass(
 
             cls.__hash__ = {cls.__name__}_hash
 
+            # By default (when slots=False), dataclasses do not have special
+            # handling for pickling, using pickle's default behavior that
+            # looks at obj.__dict__. This would also pickle the cached hash,
+            # which may change across invocations. Here, we override the
+            # pickling methods such that only fields are pickled.
+            # See also https://github.com/python/cpython/blob/5468d219df65d4fe3335e2bcc09d2f6032a32c70/Lib/dataclasses.py#L1267-L1272
             cls.__getstate__ = dataclasses._dataclass_getstate
             cls.__setstate__ = dataclasses._dataclass_setstate
             """)

--- a/pytato/array.py
+++ b/pytato/array.py
@@ -363,7 +363,7 @@ def _augment_array_dataclass(
         from pytools.codegen import remove_common_indentation
         augment_code = remove_common_indentation(
             f"""
-            import dataclasses
+            from dataclasses import fields
 
             def {cls.__name__}_hash(self):
                 try:
@@ -378,13 +378,23 @@ def _augment_array_dataclass(
             cls.__hash__ = {cls.__name__}_hash
 
             # By default (when slots=False), dataclasses do not have special
-            # handling for pickling, using pickle's default behavior that
+            # handling for pickling, thus using pickle's default behavior that
             # looks at obj.__dict__. This would also pickle the cached hash,
             # which may change across invocations. Here, we override the
             # pickling methods such that only fields are pickled.
             # See also https://github.com/python/cpython/blob/5468d219df65d4fe3335e2bcc09d2f6032a32c70/Lib/dataclasses.py#L1267-L1272
-            cls.__getstate__ = dataclasses._dataclass_getstate
-            cls.__setstate__ = dataclasses._dataclass_setstate
+
+            def _dataclass_getstate(self):
+                return [getattr(self, f.name) for f in fields(self)]
+
+
+            def _dataclass_setstate(self, state):
+                for field, value in zip(fields(self), state, strict=True):
+                    # use setattr because dataclass may be frozen
+                    object.__setattr__(self, field.name, value)
+
+            cls.__getstate__ = _dataclass_getstate
+            cls.__setstate__ = _dataclass_setstate
             """)
         exec_dict = {"cls": cls, "_MODULE_SOURCE_CODE": augment_code}
         exec(compile(augment_code,

--- a/pytato/array.py
+++ b/pytato/array.py
@@ -342,18 +342,6 @@ def _augment_array_dataclass(
     if generate_hash:
         from dataclasses import fields
 
-        attr_tuple = ", ".join(f"self.{fld.name}" for fld in fields(cls))
-        if attr_tuple:
-            attr_tuple = f"({attr_tuple},)"
-        else:
-            attr_tuple = "()"
-
-        fld_name_tuple = ", ".join(f"'{fld.name}'" for fld in fields(cls))
-        if fld_name_tuple:
-            fld_name_tuple = f"({fld_name_tuple},)"
-        else:
-            fld_name_tuple = "()"
-
         # Non-equality tags are automatically excluded from equality in
         # EqualityComparer, and are excluded here from hashing.
         attr_tuple_hash = ", ".join(f"self.{fld.name}"

--- a/test/test_codegen.py
+++ b/test/test_codegen.py
@@ -906,7 +906,7 @@ def test_einsum(ctx_factory, spec, argshapes):
     np.testing.assert_allclose(np_out, pt_out)
 
 
-def test_einsum_with_parametrized_shapes(ctx_factory):
+def test_einsum_with_parameterized_shapes(ctx_factory):
     ctx = ctx_factory()
     cq = cl.CommandQueue(ctx)
 

--- a/test/test_pytato.py
+++ b/test/test_pytato.py
@@ -1381,6 +1381,9 @@ def test_numpy_type_promotion_with_pytato_arrays():
 
 def test_pickling_hash():
     # See https://github.com/inducer/pytato/pull/563 for context
+
+    # {{{ Placeholder
+
     p = pt.make_placeholder("p", (4, 4), int)
 
     assert not hasattr(p, "_hash_value")
@@ -1395,6 +1398,32 @@ def test_pickling_hash():
     p_new = loads(dumps(p))
 
     assert not hasattr(p_new, "_hash_value")
+
+    assert p == p_new
+
+    # }}}
+
+    # {{{ DataWrapper
+
+    dw = pt.make_data_wrapper(np.zeros((4, 4), int))
+
+    assert not hasattr(dw, "_hash_value")
+
+    hash(dw)
+
+    # DataWrappers have no hash caching
+    assert not hasattr(dw, "_hash_value")
+
+    dw_new = loads(dumps(dw))
+
+    assert dw_new.shape == dw.shape
+    assert dw_new.dtype == dw.dtype
+    assert np.all(dw_new.data == dw.data)
+
+    # DataWrappers that are not the same object compare unequal
+    assert dw != dw_new
+
+    # }}}
 
 
 if __name__ == "__main__":

--- a/test/test_pytato.py
+++ b/test/test_pytato.py
@@ -1379,6 +1379,24 @@ def test_numpy_type_promotion_with_pytato_arrays():
     assert _np_result_dtype(42.0, NotReallyAnArray()) == np.float64
 
 
+def test_pickling_hash():
+    # See https://github.com/inducer/pytato/pull/563 for context
+    p = pt.make_placeholder("p", (4, 4), int)
+
+    assert not hasattr(p, "_hash_value")
+
+    # Force hash creation:
+    hash(p)
+
+    assert hasattr(p, "_hash_value")
+
+    from pickle import dumps, loads
+
+    p_new = loads(dumps(p))
+
+    assert not hasattr(p_new, "_hash_value")
+
+
 if __name__ == "__main__":
     if len(sys.argv) > 1:
         exec(sys.argv[1])


### PR DESCRIPTION
Prevents errors of the type:

`
pytato.distributed.verify.MissingSendError: no send for 'CommunicationOpIdentifier(src_rank=1, dest_rank=0, comm_tag=('fluid', (<class 'mirgecom.diffusion._DiffusionStateTag'>, (<class 'y3prediction.prediction._SmoothCharDiffFluidCommTag'>, Placeholder(shape=(), dtype='int64', name='_actx_in_1'))), (0,)))'
`

 (see e.g. https://github.com/illinois-ceesd/mirgecom/actions/runs/11958222838/job/33337251412?pr=926)

cc @MTCam

Followup of #521.

_Please squash_