### PR TITLE
Properly ignore axes tagged with `AxisIgnoredForPropagationTag` in tag propagation

### DIFF
--- a/pytato/transform/metadata.py
+++ b/pytato/transform/metadata.py
@@ -755,9 +755,6 @@ def unify_axes_tags(
     for tag, var in equations_collector.known_tag_to_var.items():
         reachable_nodes = get_reachable_subgraph(propagation_graph, var)
         for reachable_var in (reachable_nodes - known_tag_vars):
-            ary, ax = equations_collector.axis_to_var.inverse[reachable_var]
-            if ary.axes[ax].tags_of_type(AxisIgnoredForPropagationTag):
-                continue
             axis_to_solved_tags.setdefault(
                 equations_collector.axis_to_var.inverse[reachable_var],
                 set()

--- a/pytato/transform/metadata.py
+++ b/pytato/transform/metadata.py
@@ -43,7 +43,6 @@ import logging
 from typing import (
     TYPE_CHECKING,
     Any,
-    Sequence,
     cast,
 )
 

--- a/pytato/transform/metadata.py
+++ b/pytato/transform/metadata.py
@@ -43,14 +43,11 @@ import logging
 from typing import (
     TYPE_CHECKING,
     Any,
-    TypeAlias,
-    TypeVar,
+    Sequence,
     cast,
 )
 
 from bidict import bidict
-
-from collections.abc import Hashable
 
 from pytools import UniqueNameGenerator
 from pytools.tag import Tag
@@ -97,11 +94,6 @@ if TYPE_CHECKING:
 
     from pytato.function import NamedCallResult
     from pytato.loopy import LoopyCall
-
-
-
-NodeT = TypeVar("NodeT", bound=Hashable)
-GraphT: TypeAlias[NodeT] = Mapping[NodeT, Collection[NodeT]]
 
 
 # {{{ AxesTagsEquationCollector
@@ -717,8 +709,8 @@ def unify_axes_tags(
         equations_collector.equations)
 
     def get_reachable_subgraph(
-            undirected_graph: GraphT[NodeT],
-            source_node: NodeT) -> frozenset[NodeT]:
+            undirected_graph: dict[str, Sequence[str]],
+            source_node: str) -> frozenset[str]:
         """
         Partitions a graph along nodes representing axes tagged with
         `AxisIgnoredForPropagationTag` or nodes representing the

--- a/pytato/transform/metadata.py
+++ b/pytato/transform/metadata.py
@@ -708,7 +708,7 @@ def unify_axes_tags(
     propagation_graph = undirected_graph_from_edges(
         equations_collector.equations)
 
-    def get_reachable_subgraph(
+    def get_reachable_nodes(
             undirected_graph: dict[str, Sequence[str]],
             source_node: str) -> frozenset[str]:
         """
@@ -752,7 +752,7 @@ def unify_axes_tags(
     known_ax_vars = frozenset(equations_collector.axis_to_var.values())
 
     for tag, var in equations_collector.known_tag_to_var.items():
-        reachable_nodes = get_reachable_subgraph(propagation_graph, var)
+        reachable_nodes = get_reachable_nodes(propagation_graph, var)
         for reachable_var in (reachable_nodes - known_tag_vars):
             axis_to_solved_tags.setdefault(
                 equations_collector.axis_to_var.inverse[reachable_var],

--- a/pytato/transform/metadata.py
+++ b/pytato/transform/metadata.py
@@ -709,7 +709,7 @@ def unify_axes_tags(
         equations_collector.equations)
 
     def get_reachable_nodes(
-            undirected_graph: dict[str, Sequence[str]],
+            undirected_graph: Mapping[str, Collection[str]],
             source_node: str) -> frozenset[str]:
         """
         Partitions a graph along nodes representing axes tagged with

--- a/pytato/transform/metadata.py
+++ b/pytato/transform/metadata.py
@@ -43,11 +43,14 @@ import logging
 from typing import (
     TYPE_CHECKING,
     Any,
+    TypeAlias,
     TypeVar,
     cast,
 )
 
 from bidict import bidict
+
+from collections.abc import Hashable
 
 from pytools import UniqueNameGenerator
 from pytools.tag import Tag
@@ -96,7 +99,9 @@ if TYPE_CHECKING:
     from pytato.loopy import LoopyCall
 
 
-GraphNodeT = TypeVar("GraphNodeT")
+
+NodeT = TypeVar("NodeT", bound=Hashable)
+GraphT: TypeAlias[NodeT] = Mapping[NodeT, Collection[NodeT]]
 
 
 # {{{ AxesTagsEquationCollector
@@ -711,7 +716,9 @@ def unify_axes_tags(
     propagation_graph = undirected_graph_from_edges(
         equations_collector.equations)
 
-    def get_reachable_subgraph(undirected_graph, source_node):
+    def get_reachable_subgraph(
+            undirected_graph: GraphT[NodeT],
+            source_node: NodeT) -> frozenset[NodeT]:
         """
         Partitions a graph along nodes representing axes tagged with
         `AxisIgnoredForPropagationTag` or nodes representing the


### PR DESCRIPTION
Currently, tag propagation in the case of axes tagged with `AxisIgnoredForPropagationTag` is flawed in that it allows tags to be propagated through supposed ignored axes. However, the intended use is for propagation to be blocked to, from, and through ignored axes. This PR implements the intended handling by updating how reachable nodes are found in the undirected graph built from the edges computed by `AxesTagsEquationsCollector` . Effectively, nodes representing ignored axes or the `AxisIgnoredForPropagationTag` tag itself are considered partition points in the graph.