### PR TITLE
Properly handle ignored axes during tag propagation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "bidict",
     "immutabledict",
     "loopy>=2020.2",
-    "pytools>=2024.1.14",
+    "pytools>=2024.1.21",
     "pymbolic>=2024.2",
     "typing_extensions>=4",
 ]

--- a/pytato/transform/metadata.py
+++ b/pytato/transform/metadata.py
@@ -716,11 +716,17 @@ def unify_axes_tags(
         equations_collector.equations
     )
 
-    for tag, var in equations_collector.known_tag_to_var.items():
-        if isinstance(tag, AxisIgnoredForPropagationTag):
-            continue
+    ignored_vars = set()
+    for (ary, ax), ax_var in equations_collector.axis_to_var.items():
+        tags = ary.axes[ax].tags_of_type(AxisIgnoredForPropagationTag)
+        if tags:
+            ignored_vars.add(ax_var)
+            for tag in tags:
+                ignored_vars.add(equations_collector.known_tag_to_var[tag])
 
-        reachable_nodes = get_reachable_nodes(propagation_graph, var)
+    for tag, var in equations_collector.known_tag_to_var.items():
+        reachable_nodes = get_reachable_nodes(propagation_graph, var,
+                                              ignored_vars)
         for reachable_var in (reachable_nodes - known_tag_vars):
             axis_to_solved_tags.setdefault(
                 equations_collector.axis_to_var.inverse[reachable_var],

--- a/test/test_pytato.py
+++ b/test/test_pytato.py
@@ -1325,8 +1325,8 @@ def test_unify_axes_tags():
 
 
 def test_ignoring_axes_during_propagation():
-    from pytools.tag import UniqueTag
     from pytato.transform.metadata import AxisIgnoredForPropagationTag
+    from pytools.tag import UniqueTag
 
     class ElementAxisTag(UniqueTag):
         pass

--- a/test/test_pytato.py
+++ b/test/test_pytato.py
@@ -1325,8 +1325,9 @@ def test_unify_axes_tags():
 
 
 def test_ignoring_axes_during_propagation():
-    from pytato.transform.metadata import AxisIgnoredForPropagationTag
     from pytools.tag import UniqueTag
+
+    from pytato.transform.metadata import AxisIgnoredForPropagationTag
 
     class ElementAxisTag(UniqueTag):
         pass


### PR DESCRIPTION
Creates a set of partition points from nodes representing `AxisIgnoredForPropagationTag` tags and axes tagged with `AxisIgnoredForPropagationTag`. 

Utilizes https://github.com/inducer/pytools/pull/278 to traverse the propagation graph while restricting traversals to partitions defined by the previously mentioned partition points.

This PR will stay as a draft until https://github.com/inducer/pytools/pull/278 gets merged.