### PR TITLE
Allow passing `FunctionDefinition` directly to `Mapper`

### DIFF
--- a/pytato/transform/lower_to_index_lambda.py
+++ b/pytato/transform/lower_to_index_lambda.py
@@ -688,7 +688,8 @@ class ToIndexLambdaMapper(Mapper[Array, Never, []], ToIndexLambdaMixin):
     def rec(self, expr: Array) -> Array:  # type: ignore[override]
         return expr
 
-    __call__ = Mapper.rec
+    def __call__(self, expr: Array) -> Array:  # type: ignore[override]
+        return Mapper.rec(self, expr)
 
 
 def to_index_lambda(expr: Array) -> IndexLambda:


### PR DESCRIPTION
Adds an overload to `Mapper.__call__` for passing `FunctionDefinition`, instead of just `ArrayOrNames`.