### PR TITLE
Add (non-)reproducer for einsum tag cycle

### DIFF
--- a/test/test_pytato.py
+++ b/test/test_pytato.py
@@ -1844,6 +1844,34 @@ def test_pickling_hash():
     # }}}
 
 
+def test_einsum_tagging():
+    from pytools.tag import UniqueTag
+
+    class FTag(UniqueTag):
+        pass
+
+    class ATag(UniqueTag):
+        pass
+
+    class CTag(UniqueTag):
+        pass
+
+    class DTag(UniqueTag):
+        pass
+
+    p = (pt.zeros((2, 3, 4, 5))
+        .with_tagged_axis(0, FTag())
+        .with_tagged_axis(1, ATag())
+        .with_tagged_axis(2, CTag())
+        .with_tagged_axis(3, DTag()))
+
+    a = pt.zeros((2, 3, 3))
+
+    result = pt.einsum("facb, fdce, fad -> cbe", p, p, a)
+
+    pt.unify_axes_tags(result)
+
+
 if __name__ == "__main__":
     import os
     if "INVOCATION_INFO" in os.environ:


### PR DESCRIPTION
In https://notes.tiker.net/gd2gcUW3RSqMS_fPfM_RrA, @nicknytko reported a crash with the following traceback:
```
Traceback (most recent call last):
  File "/home/nnytko2/ceesd-nonlinear-solve/code/amg.py", line 508, in <module>
    mg = MultigridDGHierarchy(dcoll)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nnytko2/ceesd-nonlinear-solve/code/amg.py", line 435, in __init__
    next_level = self.levels[-1].coarsen()
                 ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nnytko2/ceesd-nonlinear-solve/code/amg.py", line 336, in coarsen
    Mc = actx.to_numpy(self.galerkin(self.M))
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nnytko2/emirge/arraycontext/arraycontext/impl/pytato/__init__.py", line 383, in to_numpy
    self._rec_map_container(_to_numpy, self.freeze(array)),
                                       ^^^^^^^^^^^^^^^^^^
  File "/home/nnytko2/emirge/arraycontext/arraycontext/impl/pytato/__init__.py", line 520, in freeze
    transformed_dag = self.transform_dag(normalized_expr)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nnytko2/emirge/meshmode/meshmode/array_context.py", line 1444, in transform_dag
    dag = unify_discretization_entity_tags(dag)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nnytko2/emirge/meshmode/meshmode/pytato_utils.py", line 108, in unify_discretization_entity_tags
    return pt.unify_axes_tags(expr,
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nnytko2/emirge/pytato/pytato/transform/metadata.py", line 776, in unify_axes_tags
    propagation_graph = undirected_graph_from_edges(
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nnytko2/emirge/miniforge3/envs/ceesd/lib/python3.12/site-packages/pytools/graph.py", line 557, in undirected_graph_from_edges
    raise TypeError("Found loop in edges,"
TypeError: Found loop in edges, LHS, RHS = ax_2
```

This PR is an attempt to reproduce the issue, without success (but as you can see, I'm guessing at the details).

@nicknytko, is there anything essential missing from the test case?

cc @a-alveyblanc (as @nicknytko mentioned you were involved in the discussion). @nicknytko mentioned that you had a fix in grudge, but that may not be enough: no matter what the tagging situation is, the crash above should not happen.