### PR TITLE
Avoid double caching in mappers that derive from `CachedMapper`

### DIFF
--- a/pytato/analysis/__init__.py
+++ b/pytato/analysis/__init__.py
@@ -626,7 +626,7 @@ class TagCountMapper(CombineMapper[int, Never]):
         try:
             return self._cache.retrieve(expr, key=key)
         except KeyError:
-            s = super().rec(expr)
+            s = Mapper.rec(self, expr)
             if (
                     isinstance(expr, Array)
                     and (

--- a/pytato/analysis/__init__.py
+++ b/pytato/analysis/__init__.py
@@ -626,6 +626,9 @@ class TagCountMapper(CombineMapper[int, Never]):
         try:
             return self._cache.retrieve(expr, key=key)
         except KeyError:
+            # Intentionally going to Mapper instead of super() to avoid
+            # double caching when subclasses of CachedMapper override rec,
+            # see https://github.com/inducer/pytato/pull/585
             s = Mapper.rec(self, expr)
             if (
                     isinstance(expr, Array)

--- a/pytato/distributed/partition.py
+++ b/pytato/distributed/partition.py
@@ -309,6 +309,8 @@ class _DistributedInputReplacer(CopyMapper):
             if name is not None:
                 return self._get_placeholder_for(name, expr)
 
+        # Calling super().rec instead of Mapper.rec is OK here, because we're not
+        # implementing cache insertion and thus are not double caching
         return cast("ArrayOrNames", super().rec(expr))
 
     def _get_placeholder_for(self, name: str, expr: Array) -> Placeholder:

--- a/pytato/transform/__init__.py
+++ b/pytato/transform/__init__.py
@@ -1532,7 +1532,7 @@ class CachedMapAndCopyMapper(CopyMapper):
             return self._cache.retrieve(expr, key=key)
         except KeyError:
             return self._cache.add(
-                expr, super().rec(self.map_fn(expr)), key=key)
+                expr, Mapper.rec(self, self.map_fn(expr)), key=key)
 
 # }}}
 

--- a/pytato/transform/__init__.py
+++ b/pytato/transform/__init__.py
@@ -421,6 +421,9 @@ class CachedMapper(Mapper[ResultT, FunctionResultT, P]):
         except KeyError:
             return self._cache.add(
                 (expr, args, kwargs),
+                # Intentionally going to Mapper instead of super() to avoid
+                # double caching when subclasses of CachedMapper override rec,
+                # see https://github.com/inducer/pytato/pull/585
                 Mapper.rec(self, expr, *args, **kwargs),
                 key=key)
 
@@ -433,6 +436,9 @@ class CachedMapper(Mapper[ResultT, FunctionResultT, P]):
         except KeyError:
             return self._function_cache.add(
                 (expr, args, kwargs),
+                # Intentionally going to Mapper instead of super() to avoid
+                # double caching when subclasses of CachedMapper override rec,
+                # see https://github.com/inducer/pytato/pull/585
                 Mapper.rec_function_definition(self, expr, *args, **kwargs),
                 key=key)
 
@@ -1535,6 +1541,9 @@ class CachedMapAndCopyMapper(CopyMapper):
             return self._cache.retrieve(expr, key=key)
         except KeyError:
             return self._cache.add(
+                # Intentionally going to Mapper instead of super() to avoid
+                # double caching when subclasses of CachedMapper override rec,
+                # see https://github.com/inducer/pytato/pull/585
                 expr, Mapper.rec(self, self.map_fn(expr)), key=key)
 
 # }}}

--- a/pytato/transform/__init__.py
+++ b/pytato/transform/__init__.py
@@ -349,6 +349,9 @@ class CachedMapperCache(Generic[CacheExprT, CacheResultT]):
             else:
                 key = self.get_key(key_inputs)
 
+        assert key not in self._expr_key_to_result, \
+            f"Cache entry is already present for key '{key}'."
+
         self._expr_key_to_result[key] = result
 
         return result

--- a/pytato/transform/__init__.py
+++ b/pytato/transform/__init__.py
@@ -2050,44 +2050,67 @@ def rec_get_user_nodes(expr: ArrayOrNames,
 
 # {{{ deduplicate_data_wrappers
 
-def _get_data_dedup_cache_key(ary: DataInterface) -> CacheKeyT:
-    import sys
-    if "pyopencl" in sys.modules:
-        from pyopencl import MemoryObjectHolder
-        from pyopencl.array import Array as CLArray
-        try:
-            from pyopencl import SVMPointer
-        except ImportError:
-            SVMPointer = None  # noqa: N806
+class DataWrapperDeduplicator(CopyMapper):
+    """
+    Mapper to replace all :class:`pytato.array.DataWrapper` instances containing
+    identical data with a single instance.
+    """
+    def __init__(
+            self,
+            _cache: TransformMapperCache[ArrayOrNames] | None = None,
+            _function_cache: TransformMapperCache[FunctionDefinition] | None = None
+            ) -> None:
+        super().__init__(_cache=_cache, _function_cache=_function_cache)
+        self.data_wrapper_cache: dict[CacheKeyT, DataWrapper] = {}
+        self.data_wrappers_encountered = 0
 
-        if isinstance(ary, CLArray):
-            base_data = ary.base_data
-            if isinstance(ary.base_data, MemoryObjectHolder):
-                ptr = base_data.int_ptr
-            elif SVMPointer is not None and isinstance(base_data, SVMPointer):
-                ptr = base_data.svm_ptr
-            elif base_data is None:
-                # pyopencl represents 0-long arrays' base_data as None
-                ptr = None
-            else:
-                raise ValueError("base_data of array not understood")
+    def _get_data_dedup_cache_key(self, ary: DataInterface) -> CacheKeyT:
+        import sys
+        if "pyopencl" in sys.modules:
+            from pyopencl import MemoryObjectHolder
+            from pyopencl.array import Array as CLArray
+            try:
+                from pyopencl import SVMPointer
+            except ImportError:
+                SVMPointer = None  # noqa: N806
 
+            if isinstance(ary, CLArray):
+                base_data = ary.base_data
+                if isinstance(ary.base_data, MemoryObjectHolder):
+                    ptr = base_data.int_ptr
+                elif SVMPointer is not None and isinstance(base_data, SVMPointer):
+                    ptr = base_data.svm_ptr
+                elif base_data is None:
+                    # pyopencl represents 0-long arrays' base_data as None
+                    ptr = None
+                else:
+                    raise ValueError("base_data of array not understood")
+
+                return (
+                        ptr,
+                        ary.offset,
+                        ary.shape,
+                        ary.strides,
+                        ary.dtype,
+                        )
+        if isinstance(ary, np.ndarray):
             return (
-                    ptr,
-                    ary.offset,
+                    ary.__array_interface__["data"],
                     ary.shape,
                     ary.strides,
                     ary.dtype,
                     )
-    if isinstance(ary, np.ndarray):
-        return (
-                ary.__array_interface__["data"],
-                ary.shape,
-                ary.strides,
-                ary.dtype,
-                )
-    else:
-        raise NotImplementedError(str(type(ary)))
+        else:
+            raise NotImplementedError(str(type(ary)))
+
+    def map_data_wrapper(self, expr: DataWrapper) -> Array:
+        self.data_wrappers_encountered += 1
+        cache_key = self._get_data_dedup_cache_key(expr.data)
+        try:
+            return self.data_wrapper_cache[cache_key]
+        except KeyError:
+            self.data_wrapper_cache[cache_key] = expr
+            return expr
 
 
 def deduplicate_data_wrappers(array_or_names: ArrayOrNames) -> ArrayOrNames:
@@ -2108,34 +2131,17 @@ def deduplicate_data_wrappers(array_or_names: ArrayOrNames) -> ArrayOrNames:
         this, but it must *also* tolerate this function doing a more thorough
         job of deduplication.
     """
+    dedup = DataWrapperDeduplicator()
+    array_or_names = dedup(array_or_names)
 
-    data_wrapper_cache: dict[CacheKeyT, DataWrapper] = {}
-    data_wrappers_encountered = 0
-
-    def cached_data_wrapper_if_present(ary: ArrayOrNames) -> ArrayOrNames:
-        nonlocal data_wrappers_encountered
-
-        if isinstance(ary, DataWrapper):
-            data_wrappers_encountered += 1
-            cache_key = _get_data_dedup_cache_key(ary.data)
-
-            try:
-                return data_wrapper_cache[cache_key]
-            except KeyError:
-                result = ary
-                data_wrapper_cache[cache_key] = result
-                return result
-        else:
-            return ary
-
-    array_or_names = map_and_copy(array_or_names, cached_data_wrapper_if_present)
-
-    if data_wrappers_encountered:
+    if dedup.data_wrappers_encountered:
         transform_logger.debug("data wrapper de-duplication: "
                                "%d encountered, %d kept, %d eliminated",
-                               data_wrappers_encountered,
-                               len(data_wrapper_cache),
-                               data_wrappers_encountered - len(data_wrapper_cache))
+                               dedup.data_wrappers_encountered,
+                               len(dedup.data_wrapper_cache),
+                               (
+                                   dedup.data_wrappers_encountered
+                                   - len(dedup.data_wrapper_cache)))
 
     return array_or_names
 

--- a/pytato/transform/__init__.py
+++ b/pytato/transform/__init__.py
@@ -418,7 +418,7 @@ class CachedMapper(Mapper[ResultT, FunctionResultT, P]):
         except KeyError:
             return self._cache.add(
                 (expr, args, kwargs),
-                super().rec(expr, *args, **kwargs),
+                Mapper.rec(self, expr, *args, **kwargs),
                 key=key)
 
     def rec_function_definition(
@@ -430,7 +430,7 @@ class CachedMapper(Mapper[ResultT, FunctionResultT, P]):
         except KeyError:
             return self._function_cache.add(
                 (expr, args, kwargs),
-                super().rec_function_definition(expr, *args, **kwargs),
+                Mapper.rec_function_definition(self, expr, *args, **kwargs),
                 key=key)
 
     def clone_for_callee(

--- a/pytato/transform/metadata.py
+++ b/pytato/transform/metadata.py
@@ -469,6 +469,9 @@ class AxisTagAttacher(CopyMapper):
         try:
             return self._cache.retrieve(expr, key=key)
         except KeyError:
+            # Intentionally going to Mapper instead of super() to avoid
+            # double caching when subclasses of CachedMapper override rec,
+            # see https://github.com/inducer/pytato/pull/585
             result = Mapper.rec(self, expr)
             if not isinstance(
                     expr, AbstractResultWithNamedArrays | DistributedSendRefHolder):


### PR DESCRIPTION
If a mapper derives from `CachedMapper` and overrides `rec` in a way that implements caching, it needs to call `Mapper.rec` instead of `super().rec` in its implementation in order to avoid executing the cache lookup/insertion logic twice. This PR intends to fix that.

The naive version of this fix had the unfortunate side effect of breaking `deduplicate_data_wrappers`, because it turns out that `deduplicate_data_wrappers` was taking advantage of this behavior in `CachedMapAndCopyMapper` in a subtle way. Here's a sketch of what was happening in the previous implementation:

Suppose we have 2 data wrappers `a` and `b` with the same data pointer.

With `super().rec`:

1) `map_fn` maps `a` to itself, then the mapper copies `a` to `a'`; it caches the mapping `a` -> `a'` (twice, once in `super().rec` and then again in `rec`),
2) `map_fn` maps `b` to `a`, then the mapper maps (via cache in `super().rec` call) `a` to `a'`; it caches the mapping `b` -> `a'`.

=> Only `a'` in output DAG.

With `Mapper.rec`:

1) `map_fn` maps `a` to itself, then the mapper copies `a` to `a'`; it caches the mapping `a` -> `a'`,
2) `map_fn` maps `b` to `a`, then the mapper copies `a` to `a''`; it caches the mapping `b` -> `a''`.

=> Both `a'` and `a''` in output DAG.

@inducer I remembered this morning that I had previously looked into this last fall (and luckily I wrote down all the details in our meeting notes). Back then I decided to set it aside and wait for #515 (after that change `map_data_wrapper` is no longer creating unnecessary copies, so it avoids the issue). But this time I thought I'd take a quick stab at refactoring `deduplicate_data_wrappers` anyway. Sticking the previous `cached_data_wrapper_if_present` implementation into `map_data_wrapper` should prevent the issue, because it gets rid of the `CopyMapper` implementation that was creating unnecessary new data wrappers.

With the changes in this PR I'm seeing a small improvement in `transform_dag` times on prediction (7% or so).