### PR TITLE
Don't assume that all ranks communicate if communication is present on some ranks

### DIFF
--- a/pytato/distributed/partition.py
+++ b/pytato/distributed/partition.py
@@ -791,6 +791,7 @@ def find_distributed_partition(
     # {{{ create (local) parts out of batch ids
 
     part_comm_ids: list[_PartCommIDs] = []
+
     if comm_batches:
         recv_ids: FrozenOrderedSet[CommunicationOpIdentifier] = FrozenOrderedSet()
         for batch in comm_batches:
@@ -811,7 +812,8 @@ def find_distributed_partition(
                 _PartCommIDs(
                     recv_ids=recv_ids,
                     send_ids=FrozenOrderedSet()))
-    else:
+
+    if not part_comm_ids:
         part_comm_ids.append(
             _PartCommIDs(
                 recv_ids=FrozenOrderedSet(),


### PR DESCRIPTION
The current distributed DAG partitioning code makes an implicit assumption when creating local parts that if `comm_batches` (global) is not empty, then the local rank must be doing some communication. This isn't necessarily true in the multi-volume case in mirgecom: if a compiled function only operates on one volume, then any ranks that don't have elements from this volume won't have any communication. In the current code, these ranks end up erroneously setting `nparts = 0`. This change makes sure that the empty ranks set `nparts = 1` instead.