### PR TITLE
Don't use deduplicated predecessors in mapper-created duplication check

### DIFF
--- a/pytato/transform/__init__.py
+++ b/pytato/transform/__init__.py
@@ -576,8 +576,11 @@ class TransformMapperCache(CachedMapperCache[CacheExprT, CacheExprT, P]):
             f"Cache entry is already present for key '{key}'."
 
         if self.err_on_created_duplicate:
-            from pytato.analysis import DirectPredecessorsGetter
-            pred_getter = DirectPredecessorsGetter(include_functions=True)
+            # For this check to work, must preserve duplicates when retrieving
+            # predecessors. DirectPredecessorsGetter deduplicates by virtue of storing
+            # the predecessors it finds in sets
+            from pytato.analysis import ListOfDirectPredecessorsGetter
+            pred_getter = ListOfDirectPredecessorsGetter(include_functions=True)
             if (
                     hash(result) == hash(inputs.expr)
                     and result == inputs.expr


### PR DESCRIPTION
`DirectPredecessorsGetter` returns a deduplicated set of predecessors, which causes problems with the "mapper-created duplication" check in `TransformMapper`. Example: Suppose an `IndexLambda` has two bindings that are duplicates of each other. When applying a mapper that deduplicates the DAG, such as `CopyMapper`, the recursion will deduplicate these two arrays, which means that a new `IndexLambda` must be created. This should not trigger the mapper-created duplicate error, because it should see that one of the predecessors has changed. However because `DirectPredecessorsGetter` deduplicates internally (by virtue of returning a `FrozenOrderedSet`), it will report that the `IndexLambda` has only one predecessor. Subsequently, the duplication check won't see that a predecessor has changed, and it will trigger the error.

This change adds a `ListOfDirectPredecessorsGetter` that returns a list instead of a set and uses that to implement the duplication check.