### PR TITLE
Revert `AxesTagsEquationCollector.map_reshape` to previous version

### DIFF
--- a/pytato/transform/metadata.py
+++ b/pytato/transform/metadata.py
@@ -349,6 +349,14 @@ class AxesTagsEquationCollector(Mapper[None, Never, []]):
         output and so no constraints are enforced except when the
         :class:`pytato.Reshape` has come from a :func:`pytato.expand_dims`.
         """
+        # Cannot use add_equations_using_index_lambda_version_of_expr here because
+        # reshapes that represent a change in the meaning of an axis may produce
+        # index expressions that look like direct passthroughs (for example,
+        # reshaping an array of shape (m*n,) to (m, n) when n == 1).
+        # We also cannot preserve "unchanged" axes, because it may be unclear which
+        # axes those actually are. For example, when reshaping (m, n) -> (m, 1, n),
+        # we can't tell from the shape alone which, if any, axes are unchanged
+        # (unless made explicit using the ExpandedDimsReshape tag).
         from pytato.tags import ExpandedDimsReshape
 
         self.rec(expr.array)

--- a/test/test_pytato.py
+++ b/test/test_pytato.py
@@ -1573,6 +1573,38 @@ def test_unify_axes_tags():
 
     # }}}
 
+    # {{{ 4. reshape
+
+    # Tags cannot propagate across reshapes
+
+    x = pt.make_placeholder("x", (10, 4))
+    x = x.with_tagged_axis(0, FooTag())
+    x = x.with_tagged_axis(1, BarTag())
+
+    y = pt.reshape(x, (5, 2, 4))
+
+    y_unified = pt.unify_axes_tags(y)
+
+    assert not y_unified.axes[0].tags_of_type(TestlibTag)
+    assert not y_unified.axes[1].tags_of_type(TestlibTag)
+    assert not y_unified.axes[2].tags_of_type(TestlibTag)
+
+    # Make sure this behaves the same with a length-1 axis
+
+    x = pt.make_placeholder("x", (5, 4))
+    x = x.with_tagged_axis(0, FooTag())
+    x = x.with_tagged_axis(1, BarTag())
+
+    y = pt.reshape(x, (5, 1, 4))
+
+    y_unified = pt.unify_axes_tags(y)
+
+    assert not y_unified.axes[0].tags_of_type(TestlibTag)
+    assert not y_unified.axes[1].tags_of_type(TestlibTag)
+    assert not y_unified.axes[2].tags_of_type(TestlibTag)
+
+    # }}}
+
     # {{ Reduction Operations with IndexLambda
     # {{{ Reduce on outside of scalar expression
 


### PR DESCRIPTION
Fixes a `NonUniqueTagError` encountered in `grudge.dt_utils.dt_geometric_factors` when reshaping an array from `(nfaces*nelements,)` to `(nfaces, nelements)` with `nelements == 1`.