### PR TITLE
Loosen type constraint on `data` in `make_dict_of_named_arrays`

### DIFF
--- a/.basedpyright/baseline.json
+++ b/.basedpyright/baseline.json
@@ -27072,14 +27072,6 @@
             {
                 "code": "reportUnknownParameterType",
                 "range": {
-                    "startColumn": 8,
-                    "endColumn": 16,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
                     "startColumn": 17,
                     "endColumn": 23,
                     "lineCount": 1

--- a/pytato/array.py
+++ b/pytato/array.py
@@ -2378,7 +2378,7 @@ def reshape(array: Array, newshape: int | Sequence[int],
 
 # {{{ make_dict_of_named_arrays
 
-def make_dict_of_named_arrays(data: dict[str, Array], *,
+def make_dict_of_named_arrays(data: Mapping[str, Array], *,
                               tags: frozenset[Tag] = frozenset()
                               ) -> DictOfNamedArrays:
     """Make a :class:`DictOfNamedArrays` object.

--- a/test/test_codegen.py
+++ b/test/test_codegen.py
@@ -1985,7 +1985,7 @@ def test_nested_function_calls(ctx_factory):
         foo_x_y = tracer(partial(foo, tracer), x, y, identifier="foo")
         return foo_x_y * x * y
 
-    def call_bar(tracer, x, y):
+    def call_bar(tracer, x, y) -> pt.Array:
         return tracer(partial(bar, tracer), x, y, identifier="bar")
 
     x1_np, y1_np = rng.random((2, 13, 29))


### PR DESCRIPTION
`DictOfNamedArrays.__init__` takes `Mapping[str, Array]`, so `make_dict_of_named_arrays` might as well use that too.