### PR TITLE
Tweak `Array` towards compatibility with arraycontext's `Array` protocol

### DIFF
--- a/.basedpyright/baseline.json
+++ b/.basedpyright/baseline.json
@@ -5028,14 +5028,6 @@
                 }
             },
             {
-                "code": "reportUnannotatedClassAttribute",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 15,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportAny",
                 "range": {
                     "startColumn": 24,
@@ -5064,174 +5056,6 @@
                 "range": {
                     "startColumn": 21,
                     "endColumn": 25,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnannotatedClassAttribute",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 11,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnannotatedClassAttribute",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 12,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnannotatedClassAttribute",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 11,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnannotatedClassAttribute",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 12,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnannotatedClassAttribute",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 11,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnannotatedClassAttribute",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 12,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnannotatedClassAttribute",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 16,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnannotatedClassAttribute",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 17,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnannotatedClassAttribute",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 15,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnannotatedClassAttribute",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 16,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnannotatedClassAttribute",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 11,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnannotatedClassAttribute",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 12,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnannotatedClassAttribute",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 11,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnannotatedClassAttribute",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 12,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnannotatedClassAttribute",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 11,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnannotatedClassAttribute",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 11,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnannotatedClassAttribute",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 12,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnannotatedClassAttribute",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 10,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnannotatedClassAttribute",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 11,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnannotatedClassAttribute",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 11,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnannotatedClassAttribute",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 12,
                     "lineCount": 1
                 }
             },
@@ -5465,38 +5289,6 @@
                     "startColumn": 6,
                     "endColumn": 17,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 23,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 26,
-                    "endColumn": 53,
-                    "lineCount": 2
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 52,
-                    "lineCount": 2
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 15,
-                    "endColumn": 52,
-                    "lineCount": 3
                 }
             },
             {
@@ -14445,30 +14237,6 @@
                     "startColumn": 8,
                     "endColumn": 24,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 35,
-                    "endColumn": 75,
-                    "lineCount": 2
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 35,
-                    "endColumn": 75,
-                    "lineCount": 2
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 35,
-                    "endColumn": 75,
-                    "lineCount": 2
                 }
             },
             {

--- a/pytato/cmath.py
+++ b/pytato/cmath.py
@@ -145,6 +145,8 @@ def _get_dtype(x: ArrayOrScalar) -> _dtype_any:
         return np.dtype(type(x))
 
 
+# FIXME: Overload these instead of returning union type?
+
 def abs(x: ArrayOrScalar) -> ArrayOrScalar:
     x_dtype = _get_dtype(x)
     if x_dtype.kind == "c":

--- a/pytato/transform/einsum_distributive_law.py
+++ b/pytato/transform/einsum_distributive_law.py
@@ -209,19 +209,19 @@ class EinsumDistributiveLawMapper(
                     _verify_is_array(self.rec(hlo.x1, ctx))
                     - _verify_is_array(self.rec(hlo.x2, ctx)))
             elif hlo.binary_op == BinaryOpType.MULT:
-                if isinstance(hlo.x1, Array) and np.isscalar(hlo.x2):
+                if isinstance(hlo.x1, Array) and not isinstance(hlo.x2, Array):
                     # https://github.com/python/mypy/issues/16499
                     return _verify_is_array(self.rec(hlo.x1, ctx)) * hlo.x2  # type: ignore[no-any-return]
                 else:
-                    assert isinstance(hlo.x2, Array) and np.isscalar(hlo.x1)
+                    assert isinstance(hlo.x2, Array) and not isinstance(hlo.x1, Array)
                     # https://github.com/python/mypy/issues/16499
                     return hlo.x1 * _verify_is_array(self.rec(hlo.x2, ctx))  # type: ignore[no-any-return]
             elif hlo.binary_op == BinaryOpType.TRUEDIV:
-                if isinstance(hlo.x1, Array) and np.isscalar(hlo.x2):
+                if isinstance(hlo.x1, Array) and not isinstance(hlo.x2, Array):
                     # https://github.com/python/mypy/issues/16499
                     return _verify_is_array(self.rec(hlo.x1, ctx)) / hlo.x2  # type: ignore[no-any-return]
                 else:
-                    assert isinstance(hlo.x2, Array) and np.isscalar(hlo.x1)
+                    assert isinstance(hlo.x2, Array) and not isinstance(hlo.x1, Array)
                     # https://github.com/python/mypy/issues/16499
                     return hlo.x1 / _verify_is_array(self.rec(hlo.x2, ctx))  # type: ignore[no-any-return]
             else:

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -27,6 +27,7 @@ THE SOFTWARE.
 """
 
 import sys
+from typing import cast
 
 import numpy as np
 
@@ -87,7 +88,10 @@ def test_apply_einsum_distributive_law_1():
     y = (7*A1 + 8*pt.sin(A2)) @ (2*x1-3*x2)
     y_transformed = apply_distributive_property_to_einsums(y, how_to_distribute)
     print(y_transformed)
-    assert y_transformed == (7 * (A1 @ (2*x1-3*x2)) + 8 * (pt.sin(A2) @ (2*x1-3*x2)))
+    assert (
+        y_transformed == (
+            7 * (A1 @ (2*x1-3*x2))
+            + 8 * (cast("pt.Array", pt.sin(A2)) @ (2*x1-3*x2))))
 
 
 def test_apply_einsum_distributive_law_2():


### PR DESCRIPTION
pyright doesn't like `partialmethod`, nor `Array.__getitem__` having an argument name that doesn't match arraycontext's `Array` protocol.