### PR TITLE
Add `send.data` as a predecessor of `DistributedSendRefHolder`

### DIFF
--- a/pytato/analysis/__init__.py
+++ b/pytato/analysis/__init__.py
@@ -402,7 +402,7 @@ class ListOfDirectPredecessorsGetter(
     def map_distributed_send_ref_holder(self,
                                         expr: DistributedSendRefHolder
                                         ) -> list[ArrayOrNames]:
-        return [expr.passthrough_data]
+        return [expr.send.data, expr.passthrough_data]
 
     def map_call(
             self, expr: Call) -> list[ArrayOrNames | FunctionDefinition]:


### PR DESCRIPTION
`map_distributed_send_ref_holder` typically calls `rec()` on `send.data`, so it should count as a predecessor.