### PR TITLE
Conda CI test env: depend on pocl>=6

### DIFF
--- a/.test-conda-env-py3.yml
+++ b/.test-conda-env-py3.yml
@@ -6,7 +6,7 @@ channels:
 dependencies:
 - python=3
 - numpy
-- pocl
+- pocl>=6
 - mako
 - pyopencl
 - islpy


### PR DESCRIPTION
Without this, conda will pick a newer graphviz, which pulls in a newer libxml2, which makes LLVM 15 unavailable, and pushes pocl onto version 1.3.

cc @majosm 