### PR TITLE
Fix `CachedMapper`'s `rec`/`rec_function_definition` typing

### DIFF
--- a/.basedpyright/baseline.json
+++ b/.basedpyright/baseline.json
@@ -1826,46 +1826,6 @@
                 }
             },
             {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownMemberType",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 26,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 22,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 22,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 19,
-                    "endColumn": 25,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportAny",
                 "range": {
                     "startColumn": 33,
@@ -6866,38 +6826,6 @@
                 }
             },
             {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 18,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownMemberType",
-                "range": {
-                    "startColumn": 21,
-                    "endColumn": 49,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 26,
-                    "endColumn": 49,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 15,
-                    "endColumn": 44,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportUnreachable",
                 "range": {
                     "startColumn": 12,
@@ -6922,42 +6850,10 @@
                 }
             },
             {
-                "code": "reportUnknownMemberType",
-                "range": {
-                    "startColumn": 43,
-                    "endColumn": 53,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 43,
-                    "endColumn": 82,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportImplicitOverride",
                 "range": {
                     "startColumn": 8,
                     "endColumn": 31,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownMemberType",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 54,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 83,
                     "lineCount": 1
                 }
             },
@@ -7518,22 +7414,6 @@
                 "range": {
                     "startColumn": 8,
                     "endColumn": 11,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownMemberType",
-                "range": {
-                    "startColumn": 43,
-                    "endColumn": 53,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 43,
-                    "endColumn": 78,
                     "lineCount": 1
                 }
             },
@@ -8294,38 +8174,6 @@
                 "range": {
                     "startColumn": 8,
                     "endColumn": 11,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 18,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownMemberType",
-                "range": {
-                    "startColumn": 21,
-                    "endColumn": 31,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 49,
-                    "endColumn": 55,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 43,
-                    "endColumn": 49,
                     "lineCount": 1
                 }
             },

--- a/.basedpyright/baseline.json
+++ b/.basedpyright/baseline.json
@@ -1826,46 +1826,6 @@
                 }
             },
             {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownMemberType",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 26,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 22,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 22,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 19,
-                    "endColumn": 25,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportAny",
                 "range": {
                     "startColumn": 33,
@@ -6658,38 +6618,6 @@
                 }
             },
             {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 18,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownMemberType",
-                "range": {
-                    "startColumn": 21,
-                    "endColumn": 49,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 26,
-                    "endColumn": 49,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 15,
-                    "endColumn": 44,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportUnreachable",
                 "range": {
                     "startColumn": 12,
@@ -6714,42 +6642,10 @@
                 }
             },
             {
-                "code": "reportUnknownMemberType",
-                "range": {
-                    "startColumn": 43,
-                    "endColumn": 53,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 43,
-                    "endColumn": 82,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportImplicitOverride",
                 "range": {
                     "startColumn": 8,
                     "endColumn": 31,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownMemberType",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 54,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 83,
                     "lineCount": 1
                 }
             },
@@ -7310,22 +7206,6 @@
                 "range": {
                     "startColumn": 8,
                     "endColumn": 11,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownMemberType",
-                "range": {
-                    "startColumn": 43,
-                    "endColumn": 53,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 43,
-                    "endColumn": 78,
                     "lineCount": 1
                 }
             },
@@ -8126,38 +8006,6 @@
                 "range": {
                     "startColumn": 8,
                     "endColumn": 11,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 18,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownMemberType",
-                "range": {
-                    "startColumn": 21,
-                    "endColumn": 31,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 49,
-                    "endColumn": 55,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 43,
-                    "endColumn": 49,
                     "lineCount": 1
                 }
             },

--- a/pytato/analysis/__init__.py
+++ b/pytato/analysis/__init__.py
@@ -56,6 +56,7 @@ from pytato.scalar_expr import SCALAR_CLASSES
 from pytato.tags import ImplStored
 from pytato.transform import (
     ArrayOrNames,
+    CachedMapper,
     CachedWalkMapper,
     CombineMapper,
     Mapper,
@@ -724,10 +725,9 @@ class TagCountMapper(CombineMapper[int, Never, []]):
         try:
             return self._cache_retrieve(inputs)
         except KeyError:
-            # Intentionally going to Mapper instead of super() to avoid
-            # double caching when subclasses of CachedMapper override rec,
-            # see https://github.com/inducer/pytato/pull/585
-            s = Mapper.rec(self, expr)
+            # Using super(CachedMapper, self) instead of super() to bypass
+            # CachedMapper.rec and avoid double caching
+            s = super(CachedMapper, self).rec(expr)
             if (
                     isinstance(expr, Array)
                     and (

--- a/pytato/analysis/__init__.py
+++ b/pytato/analysis/__init__.py
@@ -52,6 +52,7 @@ from pytato.array import (
 from pytato.function import Call, FunctionDefinition, NamedCallResult
 from pytato.transform import (
     ArrayOrNames,
+    CachedMapper,
     CachedWalkMapper,
     CombineMapper,
     Mapper,
@@ -720,10 +721,9 @@ class TagCountMapper(CombineMapper[int, Never, []]):
         try:
             return self._cache_retrieve(inputs)
         except KeyError:
-            # Intentionally going to Mapper instead of super() to avoid
-            # double caching when subclasses of CachedMapper override rec,
-            # see https://github.com/inducer/pytato/pull/585
-            s = Mapper.rec(self, expr)
+            # Using super(CachedMapper, self) instead of super() to bypass
+            # CachedMapper.rec and avoid double caching
+            s = super(CachedMapper, self).rec(expr)
             if (
                     isinstance(expr, Array)
                     and (

--- a/pytato/transform/__init__.py
+++ b/pytato/transform/__init__.py
@@ -280,15 +280,15 @@ class Mapper(Generic[ResultT, FunctionResultT, P]):
             self, expr: FunctionDefinition, *args: P.args, **kwargs: P.kwargs
             ) -> FunctionResultT:
         """Call the mapper method of *expr* and return the result."""
-        method: Callable[..., FunctionResultT] | None
-
         try:
-            method = self.map_function_definition  # type: ignore[attr-defined]
+            method_name = "map_function_definition"
+            method: Callable[..., FunctionResultT] = cast(
+                "Callable[..., FunctionResultT]",
+                getattr(self, method_name))
         except AttributeError:
             raise ValueError(
                 f"{type(self).__name__} lacks a mapper method for functions.") from None
 
-        assert method is not None
         return method(expr, *args, **kwargs)
 
     @overload
@@ -523,10 +523,11 @@ class CachedMapper(Mapper[ResultT, FunctionResultT, P]):
         try:
             return self._cache_retrieve(inputs)
         except KeyError:
-            # Intentionally going to Mapper instead of super() to avoid
-            # double caching when subclasses of CachedMapper override rec,
-            # see https://github.com/inducer/pytato/pull/585
-            return self._cache_add(inputs, Mapper.rec(self, expr, *args, **kwargs))
+            # Reminder: If overriding this in a subclass and reimplementing the cache
+            # lookup logic there, must use super(CachedMapper, self) instead of
+            # super() below to avoid double caching,
+            # see https://github.com/inducer/pytato/pull/585.
+            return self._cache_add(inputs, super().rec(expr, *args, **kwargs))
 
     def rec_function_definition(
                 self, expr: FunctionDefinition, *args: P.args, **kwargs: P.kwargs
@@ -535,11 +536,12 @@ class CachedMapper(Mapper[ResultT, FunctionResultT, P]):
         try:
             return self._function_cache_retrieve(inputs)
         except KeyError:
+            # Reminder: If overriding this in a subclass and reimplementing the cache
+            # lookup logic there, must use super(CachedMapper, self) instead of
+            # super() below to avoid double caching,
+            # see https://github.com/inducer/pytato/pull/585.
             return self._function_cache_add(
-                # Intentionally going to Mapper instead of super() to avoid
-                # double caching when subclasses of CachedMapper override rec,
-                # see https://github.com/inducer/pytato/pull/585
-                inputs, Mapper.rec_function_definition(self, expr, *args, **kwargs))
+                inputs, super().rec_function_definition(expr, *args, **kwargs))
 
     def clone_for_callee(
             self, function: FunctionDefinition) -> Self:
@@ -2004,10 +2006,10 @@ class CachedMapAndCopyMapper(CopyMapper):
         try:
             return self._cache_retrieve(inputs)
         except KeyError:
-            # Intentionally going to Mapper instead of super() to avoid
-            # double caching when subclasses of CachedMapper override rec,
-            # see https://github.com/inducer/pytato/pull/585
-            return self._cache_add(inputs, Mapper.rec(self, self.map_fn(expr)))
+            # Using super(CachedMapper, self) instead of super() to bypass
+            # CachedMapper.rec and avoid double caching
+            return self._cache_add(inputs,
+                super(CachedMapper, self).rec(self.map_fn(expr)))
 
 # }}}
 

--- a/pytato/transform/__init__.py
+++ b/pytato/transform/__init__.py
@@ -526,7 +526,7 @@ class CachedMapper(Mapper[ResultT, FunctionResultT, P]):
             # Reminder: If overriding this in a subclass and reimplementing the cache
             # lookup logic there, must use super(CachedMapper, self) instead of
             # super() below to avoid double caching,
-            # see https://github.com/inducer/pytato/pull/585.
+            # see https://github.com/inducer/pytato/pull/654.
             return self._cache_add(inputs, super().rec(expr, *args, **kwargs))
 
     def rec_function_definition(
@@ -539,7 +539,7 @@ class CachedMapper(Mapper[ResultT, FunctionResultT, P]):
             # Reminder: If overriding this in a subclass and reimplementing the cache
             # lookup logic there, must use super(CachedMapper, self) instead of
             # super() below to avoid double caching,
-            # see https://github.com/inducer/pytato/pull/585.
+            # see https://github.com/inducer/pytato/pull/654.
             return self._function_cache_add(
                 inputs, super().rec_function_definition(expr, *args, **kwargs))
 

--- a/pytato/transform/metadata.py
+++ b/pytato/transform/metadata.py
@@ -87,6 +87,7 @@ from pytato.scalar_expr import (
 from pytato.transform import (
     ArrayOrNames,
     ArrayOrNamesOrFunctionDefTc,
+    CachedMapper,
     CopyMapper,
     Mapper,
     TransformMapperCache,
@@ -516,15 +517,14 @@ class AxisTagAttacher(CopyMapper):
         try:
             return self._cache_retrieve(inputs)
         except KeyError:
-            # Intentionally going to Mapper instead of super() to avoid
-            # double caching when subclasses of CachedMapper override rec,
-            # see https://github.com/inducer/pytato/pull/585
-            result = Mapper.rec(self, expr)
+            # Using super(CachedMapper, self) instead of super() to bypass
+            # CachedMapper.rec and avoid double caching
+            result = super(CachedMapper, self).rec(expr)
             if not isinstance(
                     expr, AbstractResultWithNamedArrays | DistributedSendRefHolder):
                 assert isinstance(expr, Array)
-                # type-ignore reason: passed "ArrayOrNames"; expected "Array"
-                result = self._attach_tags(expr, result)  # type: ignore[arg-type]
+                assert isinstance(result, Array)
+                result = self._attach_tags(expr, result)
             return self._cache_add(inputs, result)
 
     def map_named_call_result(self, expr: NamedCallResult) -> Array:

--- a/pytato/transform/metadata.py
+++ b/pytato/transform/metadata.py
@@ -79,7 +79,6 @@ from pytato.array import (
     Stack,
 )
 from pytato.distributed.nodes import DistributedRecv, DistributedSendRefHolder
-from pytato.function import NamedCallResult
 from pytato.scalar_expr import (
     IDX_LAMBDA_AXIS_INDEX,
     CombineMapper,
@@ -87,6 +86,7 @@ from pytato.scalar_expr import (
 from pytato.transform import (
     ArrayOrNames,
     ArrayOrNamesOrFunctionDefTc,
+    CachedMapper,
     CopyMapper,
     Mapper,
     TransformMapperCache,
@@ -521,15 +521,14 @@ class AxisTagAttacher(CopyMapper):
         try:
             return self._cache_retrieve(inputs)
         except KeyError:
-            # Intentionally going to Mapper instead of super() to avoid
-            # double caching when subclasses of CachedMapper override rec,
-            # see https://github.com/inducer/pytato/pull/585
-            result = Mapper.rec(self, expr)
+            # Using super(CachedMapper, self) instead of super() to bypass
+            # CachedMapper.rec and avoid double caching
+            result = super(CachedMapper, self).rec(expr)
             if not isinstance(
                     expr, AbstractResultWithNamedArrays | DistributedSendRefHolder):
                 assert isinstance(expr, Array)
-                # type-ignore reason: passed "ArrayOrNames"; expected "Array"
-                result = self._attach_tags(expr, result)  # type: ignore[arg-type]
+                assert isinstance(result, Array)
+                result = self._attach_tags(expr, result)
             return self._cache_add(inputs, result)
 
     def map_named_call_result(self, expr: NamedCallResult) -> Array:


### PR DESCRIPTION
Eliminates the basedpyright warnings that appear every time a cached mapper overrides `rec`/`rec_function_definition`, e.g.:

```
pytato/transform/__init__.py:529:44 - warning: Type of "rec" is partially unknown
  Type of "rec" is "(self: Mapper[Unknown, Unknown, ...], expr: Array | AbstractResultWithNamedArrays, ...) -> Unknown" (reportUnknownMemberType)
pytato/transform/__init__.py:529:44 - warning: Argument type is unknown
  Argument corresponds to parameter "result" in function "_cache_add" (reportUnknownArgumentType)
pytato/transform/__init__.py:542:25 - warning: Type of "rec_function_definition" is partially unknown
  Type of "rec_function_definition" is "(self: Mapper[Unknown, Unknown, ...], expr: FunctionDefinition, ...) -> Unknown" (reportUnknownMemberType)
pytato/transform/__init__.py:542:25 - warning: Argument type is unknown
  Argument corresponds to parameter "result" in function "_function_cache_add" (reportUnknownArgumentType)
```

by using `super(CachedMapper, self)` instead of `Mapper`.

Testing out Claude for type checking troubleshooting. 🙂 cc @lukeolson