### PR TITLE
Add `collect_materialized_nodes`

### DIFF
--- a/.basedpyright/baseline.json
+++ b/.basedpyright/baseline.json
@@ -3808,46 +3808,6 @@
                 }
             },
             {
-                "code": "reportImplicitOverride",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 21,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportImplicitOverride",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 18,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAny",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 29,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateUsage",
-                "range": {
-                    "startColumn": 35,
-                    "endColumn": 45,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateUsage",
-                "range": {
-                    "startColumn": 42,
-                    "endColumn": 52,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 12,

--- a/pytato/analysis/__init__.py
+++ b/pytato/analysis/__init__.py
@@ -49,7 +49,11 @@ from pytato.array import (
     ShapeType,
     Stack,
 )
+from pytato.distributed.nodes import DistributedRecv, DistributedSendRefHolder
 from pytato.function import Call, FunctionDefinition, NamedCallResult
+from pytato.loopy import LoopyCall, LoopyCallResult
+from pytato.scalar_expr import SCALAR_CLASSES
+from pytato.tags import ImplStored
 from pytato.transform import (
     ArrayOrNames,
     CachedWalkMapper,
@@ -63,9 +67,6 @@ if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping
 
     import pytools.tag
-
-    from pytato.distributed.nodes import DistributedRecv, DistributedSendRefHolder
-    from pytato.loopy import LoopyCall
 
 __doc__ = """
 .. currentmodule:: pytato.analysis
@@ -88,6 +89,9 @@ __doc__ = """
 
 .. autoclass:: TagCountMapper
 .. autofunction:: get_num_tags_of_type
+
+.. autoclass:: MaterializedNodeCollector
+.. autofunction:: collect_materialized_nodes
 """
 
 
@@ -746,6 +750,103 @@ def get_num_tags_of_type(
     tcm = TagCountMapper(tag_types)
 
     return tcm(outputs)
+
+# }}}
+
+
+# {{{ MaterializedNodeCollector
+
+class MaterializedNodeCollector(CachedWalkMapper[[]]):
+    """
+    Return the nodes in a DAG that are materialized.
+
+    See :func:`collect_materialized_nodes` for more details.
+    """
+    def __init__(
+            self,
+            include_outputs: bool = True,
+            _visited_functions: set[Any] | None = None) -> None:
+        super().__init__(_visited_functions=_visited_functions)
+        self.include_outputs: bool = include_outputs
+        self.materialized_nodes: set[Array] = set()
+
+    @overload
+    def __call__(self, expr: ArrayOrNames) -> None:
+        ...
+
+    @overload
+    def __call__(self, expr: FunctionDefinition) -> None:
+        ...
+
+    @override
+    def __call__(
+            self,
+            expr: ArrayOrNames | FunctionDefinition,
+            ) -> None:
+        super().__call__(expr)
+
+        if self.include_outputs:
+            if isinstance(expr, DictOfNamedArrays):
+                self.materialized_nodes.update(expr._data.values())
+            elif isinstance(expr, Array):
+                self.materialized_nodes.add(expr)
+
+    @override
+    def get_cache_key(self, expr: ArrayOrNames) -> VisitKeyT:
+        return expr
+
+    @override
+    def get_function_definition_cache_key(self, expr: FunctionDefinition) -> VisitKeyT:
+        return expr
+
+    @override
+    def clone_for_callee(self, function: FunctionDefinition) -> Self:
+        return type(self)(
+            include_outputs=self.include_outputs,
+            _visited_functions=self._visited_functions)
+
+    @override
+    def post_visit(self, expr: ArrayOrNames | FunctionDefinition) -> None:
+        if (
+                isinstance(
+                    expr, (
+                        InputArgumentBase,
+                        DistributedRecv,
+                        CSRMatmul,
+                        LoopyCallResult,
+                        NamedCallResult))
+                or (
+                    isinstance(expr, Array)
+                    and expr.tags_of_type(ImplStored))):
+            self.materialized_nodes.add(expr)
+        elif isinstance(expr, DistributedSendRefHolder):
+            self.materialized_nodes.add(expr.send.data)
+        elif isinstance(expr, LoopyCall):
+            for subexpr in expr.bindings.values():
+                if isinstance(subexpr, Array):
+                    self.materialized_nodes.add(subexpr)
+                else:
+                    assert isinstance(subexpr, SCALAR_CLASSES)
+        elif isinstance(expr, Call):
+            self.materialized_nodes.update(expr.bindings.values())
+
+
+def collect_materialized_nodes(
+        expr: ArrayOrNames | FunctionDefinition,
+        include_outputs: bool = True) -> frozenset[Array]:
+    """
+    Return the nodes in DAG *expr* that are materialized.
+
+    The result includes:
+
+    * arrays that are materialized based on their type or usage (inputs,
+      :class:`~pytato.loopy.LoopyCall`'s bindings/results, etc.)
+    * outputs (optionally, controlled by *include_outputs*),
+    * arrays tagged with :class:`~pytato.tags.ImplStored`.
+    """
+    mac = MaterializedNodeCollector(include_outputs=include_outputs)
+    mac(expr)
+    return frozenset(mac.materialized_nodes)
 
 # }}}
 

--- a/pytato/analysis/__init__.py
+++ b/pytato/analysis/__init__.py
@@ -807,7 +807,8 @@ class MaterializedNodeCollector(CachedWalkMapper[[]]):
     @override
     def clone_for_callee(self, function: FunctionDefinition) -> Self:
         return type(self)(
-            include_outputs=self.include_outputs,
+            # include_outputs only applies to the top level __call__
+            include_outputs=True,
             _visited_functions=self._visited_functions,
             _materialized_nodes=self.materialized_nodes)
 

--- a/pytato/analysis/__init__.py
+++ b/pytato/analysis/__init__.py
@@ -29,7 +29,7 @@ THE SOFTWARE.
 from collections import defaultdict
 from typing import TYPE_CHECKING, Any, overload
 
-from orderedsets import FrozenOrderedSet
+from orderedsets import FrozenOrderedSet, OrderedSet
 from typing_extensions import Never, Self, override
 
 from loopy.tools import LoopyKeyBuilder
@@ -768,7 +768,7 @@ class MaterializedNodeCollector(CachedWalkMapper[[]]):
             _visited_functions: set[Any] | None = None) -> None:
         super().__init__(_visited_functions=_visited_functions)
         self.include_outputs: bool = include_outputs
-        self.materialized_nodes: set[Array] = set()
+        self.materialized_nodes: OrderedSet[Array] = OrderedSet()
 
     @overload
     def __call__(self, expr: ArrayOrNames) -> None:
@@ -833,7 +833,7 @@ class MaterializedNodeCollector(CachedWalkMapper[[]]):
 
 def collect_materialized_nodes(
         expr: ArrayOrNames | FunctionDefinition,
-        include_outputs: bool = True) -> frozenset[Array]:
+        include_outputs: bool = True) -> FrozenOrderedSet[Array]:
     """
     Return the nodes in DAG *expr* that are materialized.
 
@@ -846,7 +846,7 @@ def collect_materialized_nodes(
     """
     mac = MaterializedNodeCollector(include_outputs=include_outputs)
     mac(expr)
-    return frozenset(mac.materialized_nodes)
+    return FrozenOrderedSet(mac.materialized_nodes)
 
 # }}}
 

--- a/pytato/analysis/__init__.py
+++ b/pytato/analysis/__init__.py
@@ -765,10 +765,15 @@ class MaterializedNodeCollector(CachedWalkMapper[[]]):
     def __init__(
             self,
             include_outputs: bool = True,
-            _visited_functions: set[Any] | None = None) -> None:
+            _visited_functions: set[Any] | None = None,
+            _materialized_nodes: OrderedSet[Array] | None = None) -> None:
         super().__init__(_visited_functions=_visited_functions)
+
         self.include_outputs: bool = include_outputs
-        self.materialized_nodes: OrderedSet[Array] = OrderedSet()
+
+        self.materialized_nodes: OrderedSet[Array] = (
+            _materialized_nodes if _materialized_nodes is not None
+            else OrderedSet())
 
     @overload
     def __call__(self, expr: ArrayOrNames) -> None:
@@ -803,7 +808,8 @@ class MaterializedNodeCollector(CachedWalkMapper[[]]):
     def clone_for_callee(self, function: FunctionDefinition) -> Self:
         return type(self)(
             include_outputs=self.include_outputs,
-            _visited_functions=self._visited_functions)
+            _visited_functions=self._visited_functions,
+            _materialized_nodes=self.materialized_nodes)
 
     @override
     def post_visit(self, expr: ArrayOrNames | FunctionDefinition) -> None:

--- a/pytato/distributed/partition.py
+++ b/pytato/distributed/partition.py
@@ -71,7 +71,6 @@ from collections.abc import Hashable, Mapping, Sequence, Set as AbstractSet
 from functools import reduce
 from typing import (
     TYPE_CHECKING,
-    Any,
     TypeVar,
     cast,
 )
@@ -80,16 +79,13 @@ from constantdict import constantdict
 from orderedsets import FrozenOrderedSet, OrderedSet
 from typing_extensions import Never
 
-from pymbolic.mapper.optimize import optimize_mapper
 from pytools import UniqueNameGenerator, memoize_method
 from pytools.graph import CycleError
 
-from pytato.analysis import DirectPredecessorsGetter
+from pytato.analysis import DirectPredecessorsGetter, collect_materialized_nodes
 from pytato.array import Array, DictOfNamedArrays, Placeholder, make_placeholder
-from pytato.scalar_expr import SCALAR_CLASSES
 from pytato.transform import (
     ArrayOrNames,
-    CachedWalkMapper,
     CombineMapper,
     CopyMapper,
     TransformMapperCache,
@@ -569,41 +565,6 @@ def _calculate_dependency_levels(
 # }}}
 
 
-# {{{  _MaterializedArrayCollector
-
-
-@optimize_mapper(drop_args=True, drop_kwargs=True, inline_get_cache_key=True)
-class _MaterializedArrayCollector(CachedWalkMapper[[]]):
-    """
-    Collects all nodes that have to be materialized during code-generation.
-    """
-    def __init__(self) -> None:
-        super().__init__()
-        self.materialized_arrays: OrderedSet[Array] = OrderedSet()
-
-    def get_cache_key(self, expr: ArrayOrNames) -> ArrayOrNames:
-        return expr
-
-    def post_visit(self, expr: Any) -> None:
-        from pytato.loopy import LoopyCallResult
-        from pytato.tags import ImplStored
-
-        if (isinstance(expr, Array) and expr.tags_of_type(ImplStored)):
-            self.materialized_arrays.add(expr)
-
-        if isinstance(expr, LoopyCallResult):
-            self.materialized_arrays.add(expr)
-            from pytato.loopy import LoopyCall
-            assert isinstance(expr._container, LoopyCall)
-            for _, subexpr in sorted(expr._container.bindings.items()):
-                if isinstance(subexpr, Array):
-                    self.materialized_arrays.add(subexpr)
-                else:
-                    assert isinstance(subexpr, SCALAR_CLASSES)
-
-# }}}
-
-
 # {{{ _set_dict_union_mpi
 
 def _set_dict_union_mpi(
@@ -847,9 +808,6 @@ def find_distributed_partition(
 
     # {{{ assign each compulsorily materialized array to a part
 
-    materialized_arrays_collector = _MaterializedArrayCollector()
-    materialized_arrays_collector(outputs)
-
     # The sets of arrays below must have a deterministic order in order to ensure
     # that the resulting partition is also deterministic
 
@@ -865,7 +823,7 @@ def find_distributed_partition(
     # from send *nodes*, but we choose to exclude them in order to simplify the
     # processing below.
     materialized_arrays = (
-        materialized_arrays_collector.materialized_arrays
+        collect_materialized_nodes(outputs, include_outputs=False)
         - received_arrays
         - sent_arrays)
 

--- a/pytato/distributed/partition.py
+++ b/pytato/distributed/partition.py
@@ -581,8 +581,8 @@ class _MaterializedArrayCollector(CachedWalkMapper[[]]):
         super().__init__()
         self.materialized_arrays: OrderedSet[Array] = OrderedSet()
 
-    def get_cache_key(self, expr: ArrayOrNames) -> int:
-        return id(expr)
+    def get_cache_key(self, expr: ArrayOrNames) -> ArrayOrNames:
+        return expr
 
     def post_visit(self, expr: Any) -> None:
         from pytato.loopy import LoopyCallResult

--- a/pytato/transform/materialize.py
+++ b/pytato/transform/materialize.py
@@ -40,6 +40,7 @@ from pytato.array import (
     AdvancedIndexInContiguousAxes,
     AdvancedIndexInNoncontiguousAxes,
     Array,
+    ArrayOrScalar,
     AxisPermutation,
     BasicIndex,
     Concatenate,
@@ -83,6 +84,7 @@ if TYPE_CHECKING:
         DistributedSendRefHolder,
     )
     from pytato.function import FunctionDefinition, NamedCallResult
+    from pytato.loopy import LoopyCall, LoopyCallResult
 
 
 __doc__ = """
@@ -101,7 +103,7 @@ class MPMSMaterializerAccumulator:
     (i.e. the expression with tags for materialization applied).
     """
     materialized_predecessors: frozenset[Array]
-    expr: Array
+    expr: ArrayOrNames
 
 
 class MPMSMaterializerCache(
@@ -229,6 +231,7 @@ class MPMSMaterializer(
     def __init__(
             self,
             successors: Mapping[Array, list[ArrayOrNames]],
+            already_materialized_nodes: frozenset[Array],
             _cache: MPMSMaterializerCache | None = None):
         err_on_collision = __debug__
         err_on_created_duplicate = __debug__
@@ -242,6 +245,7 @@ class MPMSMaterializer(
         super().__init__(err_on_collision=err_on_collision, _cache=_cache)
 
         self.successors: Mapping[Array, list[ArrayOrNames]] = successors
+        self.already_materialized_nodes: frozenset[Array] = already_materialized_nodes
 
     @override
     def _cache_add(
@@ -282,46 +286,66 @@ class MPMSMaterializer(
                                   " supported for now.")
 
     def map_index_lambda(self, expr: IndexLambda) -> MPMSMaterializerAccumulator:
-        children_rec = {bnd_name: self.rec(bnd)
+        rec_children = {bnd_name: self.rec(bnd)
                         for bnd_name, bnd in sorted(expr.bindings.items())}
         new_children: Mapping[str, Array] = constantdict({
-            bnd_name: bnd.expr
-            for bnd_name, bnd in children_rec.items()})
-        return _materialize_if_mpms(
-            expr.replace_if_different(bindings=new_children),
-            self.successors[expr],
-            children_rec.values())
+            bnd_name: _verify_is_array(bnd.expr)
+            for bnd_name, bnd in rec_children.items()})
+        new_expr = expr.replace_if_different(bindings=new_children)
+        if expr in self.already_materialized_nodes:
+            return MPMSMaterializerAccumulator(frozenset([new_expr]), new_expr)
+        else:
+            return _materialize_if_mpms(
+                new_expr,
+                self.successors[expr],
+                rec_children.values())
 
     def map_stack(self, expr: Stack) -> MPMSMaterializerAccumulator:
         rec_arrays = [self.rec(ary) for ary in expr.arrays]
         new_arrays = tuple(ary.expr for ary in rec_arrays)
-        return _materialize_if_mpms(
-            expr.replace_if_different(arrays=new_arrays),
-            self.successors[expr],
-            rec_arrays)
+        new_expr = expr.replace_if_different(arrays=new_arrays)
+        if expr in self.already_materialized_nodes:
+            return MPMSMaterializerAccumulator(frozenset([new_expr]), new_expr)
+        else:
+            return _materialize_if_mpms(
+                new_expr,
+                self.successors[expr],
+                rec_arrays)
 
     def map_concatenate(self, expr: Concatenate) -> MPMSMaterializerAccumulator:
         rec_arrays = [self.rec(ary) for ary in expr.arrays]
         new_arrays = tuple(ary.expr for ary in rec_arrays)
-        return _materialize_if_mpms(
-            expr.replace_if_different(arrays=new_arrays),
-            self.successors[expr],
-            rec_arrays)
+        new_expr = expr.replace_if_different(arrays=new_arrays)
+        if expr in self.already_materialized_nodes:
+            return MPMSMaterializerAccumulator(frozenset([new_expr]), new_expr)
+        else:
+            return _materialize_if_mpms(
+                new_expr,
+                self.successors[expr],
+                rec_arrays)
 
     def map_roll(self, expr: Roll) -> MPMSMaterializerAccumulator:
         rec_array = self.rec(expr.array)
-        return _materialize_if_mpms(
-            expr.replace_if_different(array=rec_array.expr),
-            self.successors[expr],
-            (rec_array,))
+        new_expr = expr.replace_if_different(array=rec_array.expr)
+        if expr in self.already_materialized_nodes:
+            return MPMSMaterializerAccumulator(frozenset([new_expr]), new_expr)
+        else:
+            return _materialize_if_mpms(
+                new_expr,
+                self.successors[expr],
+                (rec_array,))
 
     def map_axis_permutation(self, expr: AxisPermutation
                              ) -> MPMSMaterializerAccumulator:
         rec_array = self.rec(expr.array)
-        return _materialize_if_mpms(
-            expr.replace_if_different(array=rec_array.expr),
-            self.successors[expr],
-            (rec_array,))
+        new_expr = expr.replace_if_different(array=rec_array.expr)
+        if expr in self.already_materialized_nodes:
+            return MPMSMaterializerAccumulator(frozenset([new_expr]), new_expr)
+        else:
+            return _materialize_if_mpms(
+                new_expr,
+                self.successors[expr],
+                (rec_array,))
 
     def _map_index_base(self, expr: IndexBase) -> MPMSMaterializerAccumulator:
         rec_array = self.rec(expr.array)
@@ -337,10 +361,15 @@ class MPMSMaterializer(
             expr.indices
             if _entries_are_identical(new_indices, expr.indices)
             else new_indices)
-        return _materialize_if_mpms(
-            expr.replace_if_different(array=rec_array.expr, indices=new_indices),
-            self.successors[expr],
-            (rec_array, *tuple(rec_indices.values())))
+        new_expr = expr.replace_if_different(
+            array=rec_array.expr, indices=new_indices)
+        if expr in self.already_materialized_nodes:
+            return MPMSMaterializerAccumulator(frozenset([new_expr]), new_expr)
+        else:
+            return _materialize_if_mpms(
+                new_expr,
+                self.successors[expr],
+                (rec_array, *tuple(rec_indices.values())))
 
     def map_basic_index(self, expr: BasicIndex) -> MPMSMaterializerAccumulator:
         return self._map_index_base(expr)
@@ -356,18 +385,26 @@ class MPMSMaterializer(
 
     def map_reshape(self, expr: Reshape) -> MPMSMaterializerAccumulator:
         rec_array = self.rec(expr.array)
-        return _materialize_if_mpms(
-            expr.replace_if_different(array=rec_array.expr),
-            self.successors[expr],
-            (rec_array,))
+        new_expr = expr.replace_if_different(array=rec_array.expr)
+        if expr in self.already_materialized_nodes:
+            return MPMSMaterializerAccumulator(frozenset([new_expr]), new_expr)
+        else:
+            return _materialize_if_mpms(
+                new_expr,
+                self.successors[expr],
+                (rec_array,))
 
     def map_einsum(self, expr: Einsum) -> MPMSMaterializerAccumulator:
         rec_args = [self.rec(ary) for ary in expr.args]
         new_args = tuple(ary.expr for ary in rec_args)
-        return _materialize_if_mpms(
-            expr.replace_if_different(args=new_args),
-            self.successors[expr],
-            rec_args)
+        new_expr = expr.replace_if_different(args=new_args)
+        if expr in self.already_materialized_nodes:
+            return MPMSMaterializerAccumulator(frozenset([new_expr]), new_expr)
+        else:
+            return _materialize_if_mpms(
+                new_expr,
+                self.successors[expr],
+                rec_args)
 
     def map_csr_matmul(self, expr: CSRMatmul) -> MPMSMaterializerAccumulator:
         rec_matrix_elem_values = self.rec(expr.matrix.elem_values)
@@ -385,38 +422,57 @@ class MPMSMaterializer(
         else:
             new_matrix = expr.matrix
         rec_array = self.rec(expr.array)
-        return _materialize_if_mpms(
-            expr.replace_if_different(
-                matrix=new_matrix,
-                array=rec_array.expr),
-            self.successors[expr],
-            (
-                rec_matrix_elem_values,
-                rec_matrix_elem_col_indices,
-                rec_matrix_row_starts,
-                rec_array))
+        new_expr = expr.replace_if_different(
+            matrix=new_matrix,
+            array=rec_array.expr)
+        assert expr in self.already_materialized_nodes
+        return MPMSMaterializerAccumulator(frozenset([new_expr]), new_expr)
 
     def map_dict_of_named_arrays(self, expr: DictOfNamedArrays
                                  ) -> MPMSMaterializerAccumulator:
         raise NotImplementedError
 
-    def map_loopy_call_result(self, expr: NamedArray) -> MPMSMaterializerAccumulator:
-        # loopy call result is always materialized
-        return MPMSMaterializerAccumulator(frozenset([expr]), expr)
+    def map_loopy_call(self, expr: LoopyCall) -> MPMSMaterializerAccumulator:
+        rec_bindings = {
+            name: self.rec(subexpr)
+            for name, subexpr in sorted(expr.bindings.items())
+            if isinstance(subexpr, Array)}
+        new_bindings: Mapping[str, ArrayOrScalar] = constantdict({
+            name: (
+                _verify_is_array(rec_bindings[name].expr)
+                if isinstance(subexpr, Array)
+                else subexpr)
+            for name, subexpr in sorted(expr.bindings.items())})
+        new_expr = expr.replace_if_different(bindings=new_bindings)
+        # materialized_predecessors isn't used by map_loopy_call_result, so don't
+        # bother creating it
+        return MPMSMaterializerAccumulator(frozenset(), new_expr)
+
+    def map_loopy_call_result(
+            self, expr: LoopyCallResult) -> MPMSMaterializerAccumulator:
+        rec_container = self.rec(expr._container)
+        new_expr = expr.replace_if_different(_container=rec_container.expr)
+        assert expr in self.already_materialized_nodes
+        return MPMSMaterializerAccumulator(frozenset([new_expr]), new_expr)
 
     def map_distributed_send_ref_holder(self,
                                         expr: DistributedSendRefHolder
                                         ) -> MPMSMaterializerAccumulator:
         rec_send_data = self.rec(expr.send.data)
         rec_passthrough = self.rec(expr.passthrough_data)
-        return MPMSMaterializerAccumulator(
-            rec_passthrough.materialized_predecessors,
-            expr.replace_if_different(
-                send=expr.send.replace_if_different(data=rec_send_data.expr),
-                passthrough_data=rec_passthrough.expr))
+        new_expr = expr.replace_if_different(
+            send=expr.send.replace_if_different(data=rec_send_data.expr),
+            passthrough_data=rec_passthrough.expr)
+        if expr in self.already_materialized_nodes:
+            return MPMSMaterializerAccumulator(frozenset([new_expr]), new_expr)
+        else:
+            return MPMSMaterializerAccumulator(
+                rec_passthrough.materialized_predecessors,
+                new_expr)
 
     def map_distributed_recv(self, expr: DistributedRecv
                              ) -> MPMSMaterializerAccumulator:
+        assert expr in self.already_materialized_nodes
         return MPMSMaterializerAccumulator(frozenset([expr]), expr)
 
     def map_named_call_result(self, expr: NamedCallResult
@@ -474,8 +530,15 @@ def materialize_with_mpms(expr: ArrayOrNamesTc) -> ArrayOrNamesTc:
         ======  ========  =======
 
     """
+    # Some nodes are materialized according to their type or usage rather than by
+    # tag; this can't easily be determined from inside MPMSMaterializer
+    from pytato.analysis import collect_materialized_nodes
+    already_materialized_nodes = collect_materialized_nodes(
+        expr, include_outputs=True)
+
     from pytato.analysis import get_list_of_users, get_num_nodes, get_num_tags_of_type
-    materializer = MPMSMaterializer(get_list_of_users(expr))
+    materializer = MPMSMaterializer(
+        get_list_of_users(expr), already_materialized_nodes)
 
     if isinstance(expr, Array):
         res = materializer(expr).expr

--- a/pytato/transform/materialize.py
+++ b/pytato/transform/materialize.py
@@ -538,7 +538,7 @@ def materialize_with_mpms(expr: ArrayOrNamesTc) -> ArrayOrNamesTc:
 
     from pytato.analysis import get_list_of_users, get_num_nodes, get_num_tags_of_type
     materializer = MPMSMaterializer(
-        get_list_of_users(expr), already_materialized_nodes)
+        get_list_of_users(expr), frozenset(already_materialized_nodes))
 
     if isinstance(expr, Array):
         res = materializer(expr).expr

--- a/test/test_pytato.py
+++ b/test/test_pytato.py
@@ -820,6 +820,138 @@ def test_large_dag_with_duplicates_count():
         dag, count_duplicates=False)
 
 
+def test_collect_materialized_nodes():
+    from pytato.analysis import collect_materialized_nodes
+    from pytato.tags import ImplStored
+
+    # {{{ inputs are materialized, intermediates are not
+
+    x = pt.make_placeholder("x", (10,))
+    y = pt.make_data_wrapper(np.arange(10))
+    z = x + y
+    expr = 2*z
+
+    result = collect_materialized_nodes(expr)
+    # result is {x, y, expr}
+    assert len(result) == 3
+    assert x in result
+    assert y in result
+    assert z not in result
+
+    # }}}
+
+    # {{{ outputs are materialized if include_outputs=True
+
+    x = pt.make_placeholder("x", (10,))
+    y = pt.make_placeholder("y", (10,))
+    expr = x + y
+
+    result = collect_materialized_nodes(expr)
+    assert expr in result
+
+    result = collect_materialized_nodes(expr, include_outputs=False)
+    assert expr not in result
+
+    # }}}
+
+    # {{{ ImplStored-tagged nodes are materialized
+
+    x = pt.make_placeholder("x", (10,))
+    y = pt.make_placeholder("y", (10,))
+    z = (x + y).tagged(ImplStored())
+    expr = 2*z
+
+    result = collect_materialized_nodes(expr)
+    assert z in result
+
+    # }}}
+
+    # {{{ CSRMatmul is materialized
+
+    elem_values = pt.make_placeholder("elem_values", (8,))
+    elem_col_indices = pt.make_placeholder("elem_col_indices", (8,))
+    row_starts = pt.make_placeholder("row_starts", (9,))
+    mat = pt.make_csr_matrix(
+        shape=(8, 10),
+        elem_values=elem_values,
+        elem_col_indices=elem_col_indices,
+        row_starts=row_starts)
+    vec = pt.make_placeholder("vec", (10,))
+    z = mat @ vec
+    expr = 2*z
+    result = collect_materialized_nodes(expr)
+    # result is {elem_values, elem_col_indices, row_starts, vec, z, expr}
+    assert len(result) == 6
+    assert z in result
+
+    # }}}
+
+    # {{{ LoopyCall bindings and outputs are materialized
+
+    import loopy as lp
+
+    from pytato.loopy import call_loopy
+
+    x = pt.make_placeholder("x", (10, 4), np.float64)
+    y = 2*x
+    knl = lp.make_function(
+            "{[i, j]: 0<=i<10 and 0<=j<4}",
+            """
+            Z[i] = sum(j, Y[i, j])
+            """, name="callee")
+    loopy_result = call_loopy(knl, bindings={"Y": y}, entrypoint="callee")
+    z = loopy_result["Z"]
+    expr = 2*z
+    result = collect_materialized_nodes(expr)
+    # result is {x, y, z, expr}
+    assert len(result) == 4
+    assert y in result
+    assert z in result
+
+    # }}}
+
+    # {{{ Call bindings and FunctionDefinition results are materialized
+
+    def f(a, b):
+        return a + b
+
+    x = pt.make_placeholder("x", (10,), np.float64)
+    y = pt.make_placeholder("y", (10,), np.float64)
+    u = 2*x
+    v = 3*y
+    z = pt.trace_call(f, u, v)
+    func_def = z.call.function
+    expr = 2*z
+
+    result = collect_materialized_nodes(expr)
+    assert u in result
+    assert v in result
+    for ret_expr in func_def.returns.values():
+        assert ret_expr in result
+
+    # Only the top level outputs are affected by include_outputs
+    result = collect_materialized_nodes(expr, include_outputs=False)
+    for ret_expr in func_def.returns.values():
+        assert ret_expr in result
+
+    # }}}
+
+    # {{{ DistributedSendRefHolder materializes send's data
+
+    x = pt.make_placeholder("x", (10,))
+    send_data = 2*x
+    send = pt.make_distributed_send(send_data, dest_rank=1, comm_tag="tag")
+    passthrough = pt.make_placeholder("pt", (10,))
+    send_ref = pt.make_distributed_send_ref_holder(send, passthrough)
+
+    result = collect_materialized_nodes(send_ref)
+    # result is {x, send_data, passthrough, send_ref}
+    assert len(result) == 4
+    assert send_data in result
+
+    # }}}
+
+
 def test_rec_get_user_nodes():
     x1 = pt.make_placeholder("x1", shape=(10, 4))
     x2 = pt.make_placeholder("x2", shape=(10, 4))


### PR DESCRIPTION
This PR adds a `collect_materialized_nodes` function that identifies all materialized nodes, including those that are implicitly materialized based on their use by another node (e.g., `LoopyCall` ins/outs, `DistributedSend` data). It also attempts to use this function to unify the identification of materialized nodes elsewhere in the code, namely MPMS materialization and distributed partitioning.

Summary of changes:

* Adds `MaterializedNodeCollector` and `collect_materialized_nodes` to analysis.
* Replaces/generalizes existing `_MaterializedArrayCollector` in distributed.
* Fixes an issue with `MPMSMaterializer` not traversing `LoopyCall`'s bindings.
* Updates `MPMSMaterializer` to be aware of implicitly-materialized arrays.